### PR TITLE
fix: Fix blog redirect, and redirect outdated pg_analytics and pg_lakehouse posts over to pg_search

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -25,6 +25,7 @@ const nextConfig = {
         source: '/blog/introducing_lakehouse',
         destination: 'https://www.paradedb.com/blog/introducing_search',
         permanent: true,
+      },
       {
         source: '/blog/introducing_analytics',
         destination: 'https://www.paradedb.com/blog/introducing_search',

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -7,6 +7,35 @@ const nextConfig = {
   // Configure `pageExtensions` to include markdown and MDX files
   pageExtensions: ["js", "jsx", "md", "mdx", "ts", "tsx"],
   // Optionally, add any other Next.js config below
+
+  async redirects() {
+    return [
+      // Subdomain redirect (from previous step)
+      {
+        source: '/:path*',
+        has: [
+          {
+            type: 'host',
+            value: 'blog.paradedb.com',
+          },
+        ],
+        destination: 'https://paradedb.com/blog/:path*',
+        permanent: true,
+      },
+      // Redirect for old blog post: introducing_lakehouse
+      {
+        source: '/blog/introducing_lakehouse',
+        destination: 'https://www.paradedb.com/blog/introducing_search',
+        permanent: true, // Use 308 for permanent redirect, good for SEO
+      },
+      // Redirect for old blog post: introducing_analytics
+      {
+        source: '/blog/introducing_analytics',
+        destination: 'https://www.paradedb.com/blog/introducing_search',
+        permanent: true, // Use 308 for permanent redirect, good for SEO
+      },
+    ];
+  },
 };
 
 const withMDX = createMDX({

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -10,7 +10,6 @@ const nextConfig = {
 
   async redirects() {
     return [
-      // Subdomain redirect (from previous step)
       {
         source: '/:path*',
         has: [
@@ -22,17 +21,14 @@ const nextConfig = {
         destination: 'https://paradedb.com/blog/:path*',
         permanent: true,
       },
-      // Redirect for old blog post: introducing_lakehouse
       {
         source: '/blog/introducing_lakehouse',
         destination: 'https://www.paradedb.com/blog/introducing_search',
-        permanent: true, // Use 308 for permanent redirect, good for SEO
-      },
-      // Redirect for old blog post: introducing_analytics
+        permanent: true,
       {
         source: '/blog/introducing_analytics',
         destination: 'https://www.paradedb.com/blog/introducing_search',
-        permanent: true, // Use 308 for permanent redirect, good for SEO
+        permanent: true,
       },
     ];
   },

--- a/src/app/blog/page.tsx
+++ b/src/app/blog/page.tsx
@@ -1,7 +1,0 @@
-import { blog } from "@/lib/links";
-import { redirect } from "next/navigation";
-import { siteConfig } from "../siteConfig";
-
-export default function Blog() {
-  redirect(`${siteConfig.baseLinks.blog}/${blog[0].href}`);
-}

--- a/vercel.json
+++ b/vercel.json
@@ -1,9 +1,0 @@
-{
-  "redirects": [
-    {
-      "source": "/pages/:path*",
-      "destination": "/blog/:path*",
-      "permanent": true
-    }
-  ]
-}


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #N/A

## What
Going to `blog.paradedb.com` didn't redirect to `paradedb.com/blog` like it should. I also redirected the `pg_analytics` and `pg_lakehouse` blog posts to `pg_search`, since they're removed in #58.

## Why
Working blog.

## How
Some vibecoding redirection.

## Tests
Tested manually via curl:

```
philippemnoel /Users/philippemnoel/Downloads/paradedb/terraform-paradedb-byoc (dev) $ curl -I -H "Host: blog.paradedb.com" http://localhost:3000/foo

HTTP/1.1 308 Permanent Redirect
location: https://paradedb.com/blog/foo
Refresh: 0;url=https://paradedb.com/blog/foo
Date: Fri, 08 Aug 2025 19:05:40 GMT
Connection: keep-alive
Keep-Alive: timeout=5

philippemnoel /Users/philippemnoel/Downloads/paradedb/terraform-paradedb-byoc (dev) $ curl -I http://localhost:3000/blog/introducing_lakehouse

HTTP/1.1 308 Permanent Redirect
location: https://www.paradedb.com/blog/introducing_search
Refresh: 0;url=https://www.paradedb.com/blog/introducing_search
Date: Fri, 08 Aug 2025 19:05:51 GMT
Connection: keep-alive
Keep-Alive: timeout=5


philippemnoel /Users/philippemnoel/Downloads/paradedb/terraform-paradedb-byoc (dev) $ curl -I http://localhost:3000/blog/introducing_analytics

HTTP/1.1 308 Permanent Redirect
location: https://www.paradedb.com/blog/introducing_search
Refresh: 0;url=https://www.paradedb.com/blog/introducing_search
Date: Fri, 08 Aug 2025 19:05:59 GMT
Connection: keep-alive
```
