### PR TITLE
Fix: Change h1 to look like h2 on blog

### DIFF
--- a/src/components/markdown/elasticsearch-was-never-a-database.mdx
+++ b/src/components/markdown/elasticsearch-was-never-a-database.mdx
@@ -2,7 +2,7 @@ import Image from "next/image";
 import Headshot from "../../../public/blog/james_headshot.jpeg";
 import ElasticWasNever from "../../../public/blog/elasticsearch-was-never-a-database.svg";
 
-## Elasticsearch Was Never a Database
+# Elasticsearch Was Never a Database
 
 <div className="relative bottom-10 flex h-6 space-x-3">
   <Image src={Headshot} className="h-7 w-7 rounded-full" />

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -13,6 +13,11 @@ const config: Config = {
       typography: {
         DEFAULT: {
           css: {
+	    ".prose h1": {
+              fontSize: "1.5rem",   // ~24px
+              lineHeight: "2rem",   // ~32px
+              fontWeight: "700",
+            },
             ".prose ul": {
               listStyleType: "disc",
               paddingLeft: "1.25rem",


### PR DESCRIPTION
This is to fix using h2 for the h1 because it looks too big.

- Only change .prose
- Update most recent blog to test


