### PR TITLE
chore: Point to install page instead of quickstart

### DIFF
--- a/src/app/blog/elasticsearch-acid-test/index.mdx
+++ b/src/app/blog/elasticsearch-acid-test/index.mdx
@@ -98,4 +98,4 @@ ParadeDB removes that complexity. By extending Postgres with BM25-powered search
 
 _And you don’t have to replace what you already run. ParadeDB can serve as your primary database, or as a logical replica that delivers real-time search next to your existing Postgres server._
 
-Ready to try ACID-compliant search? [Get started with ParadeDB](https://docs.paradedb.com/documentation/getting-started/quickstart), and please don’t hesitate to [give us a star](https://github.com/paradedb/paradedb).
+Ready to try ACID-compliant search? [Get started with ParadeDB](https://docs.paradedb.com/documentation/getting-started/install), and please don’t hesitate to [give us a star](https://github.com/paradedb/paradedb).

--- a/src/app/blog/hybrid-search-in-postgresql-the-missing-manual/index.mdx
+++ b/src/app/blog/hybrid-search-in-postgresql-the-missing-manual/index.mdx
@@ -260,4 +260,4 @@ Hybrid search in PostgreSQL combines BM25's lexical precision with vector embedd
 
 The SQL-based approach means you can see exactly how rankings work, adjust weights intuitively, and add business logic as needed. No black-box algorithms or complex external systems to manage.
 
-Ready to get started? [Install ParadeDB](https://docs.paradedb.com/documentation/getting-started/quickstart) and use RRF to combine BM25 with pgvector into hybrid search that actually works, and please don’t hesitate to [give us a star](https://github.com/paradedb/paradedb).
+Ready to get started? [Install ParadeDB](https://docs.paradedb.com/documentation/getting-started/install) and use RRF to combine BM25 with pgvector into hybrid search that actually works, and please don’t hesitate to [give us a star](https://github.com/paradedb/paradedb).

--- a/src/app/blog/increased-write-performance/index.mdx
+++ b/src/app/blog/increased-write-performance/index.mdx
@@ -154,4 +154,4 @@ Write performance is just one piece of the larger puzzle. ParadeDB already offer
 
 Our combination of Postgres's ACID guarantees with Elasticsearch-level search performance opens up exciting possibilities for application architectures. Instead of managing separate systems for transactions and search, developers can build on a single, consistent foundation.
 
-Ready to experience faster search indexing? [Get started with ParadeDB](https://docs.paradedb.com/documentation/getting-started/quickstart) to see how write-optimized search can simplify your architecture, and please don’t hesitate to [give us a star](https://github.com/paradedb/paradedb).
+Ready to experience faster search indexing? [Get started with ParadeDB](https://docs.paradedb.com/documentation/getting-started/install) to see how write-optimized search can simplify your architecture, and please don’t hesitate to [give us a star](https://github.com/paradedb/paradedb).

--- a/src/app/blog/paradedb-0-20-0/index.mdx
+++ b/src/app/blog/paradedb-0-20-0/index.mdx
@@ -213,4 +213,4 @@ Again, you can expect a follow up post with all the gory data-structure details.
 
 Version `0.20.0` strengthens ParadeDB as an alternative to Elasticsearch by adding fast search aggregations, a streamlined v2 API, and significantly improved write performance directly into PostgreSQL. For teams that value transactional consistency and operational simplicity, we provide a path to modern search capabilities without the complexity of managing separate systems.
 
-Ready to see search aggregations and the new API in action? [Try ParadeDB 0.20.0](https://docs.paradedb.com/documentation/getting-started/quickstart) and experience what it's like when search, analytics, and transactions work together seamlessly.
+Ready to see search aggregations and the new API in action? [Try ParadeDB 0.20.0](https://docs.paradedb.com/documentation/getting-started/install) and experience what it's like when search, analytics, and transactions work together seamlessly.

--- a/src/app/blog/v2api/index.mdx
+++ b/src/app/blog/v2api/index.mdx
@@ -32,7 +32,7 @@ In this post, we’ll walk through what’s new, and how the v2 API brings Parad
 
 The foundation of the v2 API is improved schema inference. When you create a search index, ParadeDB examines your existing table structure and automatically configures appropriate search behavior for each column type (rather than maintaining a separate JSON configuration blob). We believe your PostgreSQL schema should be the authoritative source of truth, so we built the system to work with what you already have.
 
-All the code examples in this post use the ParadeDB getting started demo table (which you can easily install by [following the SQL steps here](https://docs.paradedb.com/documentation/getting-started/quickstart)).
+All the code examples in this post use the ParadeDB getting started demo table (which you can easily install by [following the SQL steps here](https://docs.paradedb.com/documentation/getting-started/install)).
 
 ```ini
 Table "public.mock_items"
@@ -429,8 +429,8 @@ The v2 API provides three advanced capabilities for sophisticated search require
 
 This post covers the core features of the v2 API, but there's much more to explore. For the complete feature set, including advanced ranking options, custom analyzers, and specialized query types, check out the [full documentation](https://docs.paradedb.com/documentation/full-text/overview).
 
-All the examples in this post use ParadeDB's [`mock_items` table](https://docs.paradedb.com/documentation/getting-started/quickstart), which you can install and try yourself following the getting started guide. Every query shown here works with the demo data, allowing you to explore the v2 API's capabilities hands-on.
+All the examples in this post use ParadeDB's `mock_items` table, which you can install and try yourself following the [getting started guide](https://docs.paradedb.com/documentation/getting-started/install). Every query shown here works with the demo data, allowing you to explore the v2 API's capabilities hands-on.
 
 The v2 API represents our vision for how search should work in SQL databases: powerful, flexible, and integrated rather than separate and complex. Because ParadeDB runs inside PostgreSQL, you get all the PostgreSQL guarantees you rely on: ACID transactions, backup and recovery, security, and the entire ecosystem of extensions and tools.
 
-[Get started with ParadeDB](https://docs.paradedb.com/documentation/getting-started/quickstart) to see how the v2 API can simplify your search architecture while expanding your search capabilities, and please don’t hesitate to [give us a star](https://github.com/paradedb/paradedb).
+[Get started with ParadeDB](https://docs.paradedb.com/documentation/getting-started/install) to see how the v2 API can simplify your search architecture while expanding your search capabilities, and please don’t hesitate to [give us a star](https://github.com/paradedb/paradedb).

--- a/src/app/blog/when-tokenization-becomes-token/index.mdx
+++ b/src/app/blog/when-tokenization-becomes-token/index.mdx
@@ -115,7 +115,7 @@ Tokenization doesn’t get the glory. Nobody brags about their stopword filter a
 
 Every search engine invests heavily here because everything else (scoring, ranking, relevance) depends on getting tokens right. It’s not glamorous, but it’s precise, and when you get this part right, everything else in search works better.
 
-[Get started with ParadeDB](https://docs.paradedb.com/documentation/getting-started/quickstart) to see how modern search databases handle tokenization for you, and please don’t hesitate to [give us a star](https://github.com/paradedb/paradedb).
+[Get started with ParadeDB](https://docs.paradedb.com/documentation/getting-started/install) to see how modern search databases handle tokenization for you, and please don’t hesitate to [give us a star](https://github.com/paradedb/paradedb).
 
 ---
 


### PR DESCRIPTION
# Ticket(s) Closed
## What
Link to https://docs.paradedb.com/documentation/getting-started/install instead of https://docs.paradedb.com/documentation/getting-started/quickstart as it will soon be removed.

## Why
See https://github.com/paradedb/paradedb/pull/4652

## How

## Tests
