### PR TITLE
chore: SEO - Improve case study indexing via internal links

### DIFF
--- a/public/llms.txt
+++ b/public/llms.txt
@@ -38,7 +38,9 @@
 - [Alibaba Picks ParadeDB to Bring Full Text Search to its Postgres-Based Data Warehouse](https://www.paradedb.com/customers/case-study-alibaba)
 - [Bilt Reduces Postgres Query Timeouts by 95% with ParadeDB](https://www.paradedb.com/customers/case-study-bilt)
 - [INSA Strasbourg Powers New Research Database with ParadeDB](https://www.paradedb.com/customers/case-study-insa)
+- [ParadeDB Powers Modern Treasury's Core UI and Search APIs](https://www.paradedb.com/customers/case-study-modern-treasury)
 - [Sweetspot Unifies Hybrid Search on Postgres with ParadeDB](https://www.paradedb.com/customers/case-study-sweetspot)
+- [Terrapin Finance Cuts Bond Search Latency by 25x with ParadeDB](https://www.paradedb.com/customers/case-study-terrapin-finance)
 
 ## Learn
 

--- a/src/app/blog/elasticsearch-vs-postgres/index.mdx
+++ b/src/app/blog/elasticsearch-vs-postgres/index.mdx
@@ -75,5 +75,7 @@ While each service differentiates around the edges, there’s an important cavea
 
 ParadeDB is a full text search engine built for Postgres. Powered by an extension called `pg_search`, ParadeDB embeds Tantivy, a Rust-based Lucene alternative, inside Postgres. Like native Postgres FTS, ParadeDB plugs into any existing, self-managed Postgres database with no additional infrastructure. Like Elasticsearch, ParadeDB provides the capabilities of an advanced full text search engine.
 
+Teams making this tradeoff have already made the switch: [INSA Strasbourg replaced Elasticsearch with ParadeDB](/customers/case-study-insa) to simplify their research database stack, and [Bilt cut Postgres query timeouts by 95%](/customers/case-study-bilt) without standing up a separate search cluster.
+
 Compatibility with managed Postgres services like Amazon RDS is coming soon. To get notified when it’s ready, we invite you to fill out our [interest form](https://form.typeform.com/to/jHkLmIzx?typeform-source=paradedb.typeform.com).
 In the meantime, you can follow our [GitHub repository](https://github.com/paradedb/paradedb) and give us a star!

--- a/src/app/blog/elasticsearch-was-never-a-database/index.mdx
+++ b/src/app/blog/elasticsearch-was-never-a-database/index.mdx
@@ -93,6 +93,8 @@ Even when used “correctly”, though, the hardest part often isn’t search it
 
 That’s where ParadeDB comes in. Run it as your primary database, combining OLTP and full-text search in one system, or keep your existing Postgres database and eliminate ETL by deploying it as a logical follower.
 
+This is the path teams like [INSA Strasbourg](/customers/case-study-insa) and [Modern Treasury](/customers/case-study-modern-treasury) have taken — replacing brittle search pipelines with ParadeDB running alongside Postgres.
+
 If you want open-source search with correctness, simplicity, and world-class performance, [get started with ParadeDB](https://www.paradedb.com), and please don’t hesitate to [give us a star](https://github.com/paradedb/paradedb).
 
 ---

--- a/src/components/ui/SocialProof.tsx
+++ b/src/components/ui/SocialProof.tsx
@@ -121,6 +121,16 @@ export default function SocialProof() {
                   />
                 </div>
               </div>
+
+              <div className="mt-10 flex justify-center">
+                <Link
+                  href="/customers"
+                  className="group inline-flex items-center gap-2 text-indigo-950 dark:text-white font-semibold hover:text-indigo-600 dark:hover:text-indigo-400 transition-colors duration-200"
+                >
+                  View all case studies
+                  <RiArrowRightLine className="size-4 transition-transform duration-200 group-hover:translate-x-1" />
+                </Link>
+              </div>
             </div>
           </div>
         </div>


### PR DESCRIPTION
# Ticket(s) Closed

None

## What

Strengthen internal linking to customer case studies to address a Google Search Console indexing gap flagged by Gauge.

## Why

GSC shows `/customers/case-study-insa` and `/customers/case-study-terrapin-finance` have zero impressions and are likely not indexed, despite being present in the sitemap with valid metadata and canonical URLs. The root cause is weak internal linking: only Bilt and Alibaba are linked from the homepage, `llms.txt` was missing two of the six case studies, and no blog posts cross-link to case studies. Case studies are high-intent content for developers evaluating ParadeDB against Elasticsearch — they need to be surfaced and cross-linked to get crawled and ranked.

## How

**`public/llms.txt`**

- Added missing entries for `case-study-modern-treasury` and `case-study-terrapin-finance` so the Customers section lists all 6 case studies.

**`src/components/ui/SocialProof.tsx`**

- Added a "View all case studies" link below the two featured case study cards (Bilt and Alibaba) on the homepage, pointing to `/customers`. Uses the existing `RiArrowRightLine` icon and matches the existing link styling with a hover translate on the arrow.

**Blog cross-links**

- `src/app/blog/elasticsearch-vs-postgres/index.mdx` — Added a paragraph in the "Is the Best of Both Worlds Possible?" section linking to `/customers/case-study-insa` (replaced Elasticsearch) and `/customers/case-study-bilt` (cut query timeouts 95%).
- `src/app/blog/elasticsearch-was-never-a-database/index.mdx` — Added a sentence near the "That's where ParadeDB comes in" paragraph linking to `/customers/case-study-insa` and `/customers/case-study-modern-treasury`.

## Tests

- `pnpm run lint` passes (pre-existing warnings only, 0 new).
- `prettier --check "src/**/*.{ts,tsx}"` passes.
- Manual verification:
  - Homepage SocialProof section renders the new "View all case studies" link with correct hover state.
  - Both updated blog posts render the new paragraphs with working links to `/customers/case-study-*`.
  - Post-merge: submit `/customers/case-study-insa` and `/customers/case-study-terrapin-finance` via GSC URL Inspection → Request Indexing.