### PR TITLE
chore: Update Docker pulls count to 1M

### DIFF
--- a/src/components/ui/CommunityProof.tsx
+++ b/src/components/ui/CommunityProof.tsx
@@ -39,7 +39,7 @@ export default function CommunityProof() {
                     <DockerLogo className="w-full h-full dark:brightness-0 dark:invert" />
                   </div>
                   <div className="text-2xl font-bold text-indigo-950 dark:text-white mb-2">
-                    500K+
+                    1M+
                   </div>
                   <div className="font-semibold text-slate-900 dark:text-slate-100 mb-2">
                     Docker deployments


### PR DESCRIPTION
# Ticket(s) Closed

None

## What

Update the Docker deployments counter on the community proof section from `500K+` to `1M+`.

## Why

ParadeDB's Docker image has surpassed 1 million pulls — the displayed number was stale.

## How

**`src/components/ui/CommunityProof.tsx`**

- Docker card stat: `500K+` → `1M+`

## Tests

- Visual confirmation in dev server that the Docker card shows `1M+`