### PR TITLE
chore: Update extension installs to 200K and DigitalOcean CTA copy

### DIFF
--- a/src/app/blog/series-a-announcement/index.mdx
+++ b/src/app/blog/series-a-announcement/index.mdx
@@ -10,7 +10,8 @@ import heroImage from "./images/hero.svg";
 <HeroImage src={heroImage} metadata={blogMetadata} />
 
 <Note>
-  Read this announcement on [TechCrunch](https://techcrunch.com/2025/07/15/paradedb-takes-on-elasticsearch-as-interest-in-postgres-explodes-amid-ai-boom/).
+  Read this announcement on
+  [TechCrunch](https://techcrunch.com/2025/07/15/paradedb-takes-on-elasticsearch-as-interest-in-postgres-explodes-amid-ai-boom/).
 </Note>
 
 We're excited to announce our $12M Series A fundraising round, led by [Craft Ventures](https://craftventures.com/) and joined by existing investors including [Y Combinator](https://ycombinator.com). This brings our total capital raised to $14M and accelerates our mission to build a modern Elasticsearch alternative on Postgres.

--- a/src/app/blog/series-a-announcement/index.mdx
+++ b/src/app/blog/series-a-announcement/index.mdx
@@ -2,11 +2,16 @@ import blogMetadata from "./metadata.json";
 import { AuthorSection } from "@/components/AuthorSection";
 import { HeroImage } from "@/components/HeroImage";
 import { Title } from "@/components/Title";
+import { Note } from "@/components/mdx/Callouts";
 import heroImage from "./images/hero.svg";
 
 <Title metadata={blogMetadata} />
 <AuthorSection metadata={blogMetadata} />
 <HeroImage src={heroImage} metadata={blogMetadata} />
+
+<Note>
+  Read this announcement on [TechCrunch](https://techcrunch.com/2025/07/15/paradedb-takes-on-elasticsearch-as-interest-in-postgres-explodes-amid-ai-boom/).
+</Note>
 
 We're excited to announce our $12M Series A fundraising round, led by [Craft Ventures](https://craftventures.com/) and joined by existing investors including [Y Combinator](https://ycombinator.com). This brings our total capital raised to $14M and accelerates our mission to build a modern Elasticsearch alternative on Postgres.
 

--- a/src/components/ui/AgentReady.tsx
+++ b/src/components/ui/AgentReady.tsx
@@ -134,13 +134,13 @@ const Frameworks = [
   {
     name: "Python",
     className: "text-slate-900 dark:text-slate-100",
-    url: "https://github.com/paradedb/django-paradedb",
+    url: "https://docs.paradedb.com/documentation/getting-started/environment#django",
     icon: <PythonIcon className="size-[1.6rem]" />,
   },
   {
     name: "Ruby",
     className: "text-slate-900 dark:text-slate-100 -translate-y-[2px]",
-    url: "https://github.com/paradedb/rails-paradedb",
+    url: "https://docs.paradedb.com/documentation/getting-started/environment#rails",
     icon: <RubyIcon className="size-[1.4rem]" />,
   },
 ];

--- a/src/components/ui/AgentReady.tsx
+++ b/src/components/ui/AgentReady.tsx
@@ -389,10 +389,7 @@ export default function AgentReady() {
                             target="_blank"
                             className="mt-auto flex w-fit items-center gap-1 text-sm font-semibold text-indigo-600 dark:text-indigo-400 hover:text-indigo-700 dark:hover:text-indigo-300"
                           >
-                            {CloudPlatforms[selectedCloud].name ===
-                            "DigitalOcean"
-                              ? "Read Guide"
-                              : `Deploy to ${CloudPlatforms[selectedCloud].name}`}
+                            Deploy to {CloudPlatforms[selectedCloud].name}
                             <RiArrowRightLine className="size-4" />
                           </Link>
                         </div>

--- a/src/components/ui/CommunityProof.tsx
+++ b/src/components/ui/CommunityProof.tsx
@@ -92,7 +92,7 @@ export default function CommunityProof() {
                     8K+
                   </div>
                   <div className="font-semibold text-slate-900 dark:text-slate-100 mb-2">
-                    Stargazers on Github
+                    Stargazers on GitHub
                   </div>
                   <p className="text-sm text-slate-600 dark:text-slate-400 mb-6 leading-relaxed">
                     ParadeDB is one of the fastest-growing open source database

--- a/src/components/ui/CommunityProof.tsx
+++ b/src/components/ui/CommunityProof.tsx
@@ -64,7 +64,7 @@ export default function CommunityProof() {
                     <PostgresLogo className="w-full h-full" />
                   </div>
                   <div className="text-2xl font-bold text-indigo-950 dark:text-white mb-2">
-                    100K+
+                    200K+
                   </div>
                   <div className="font-semibold text-slate-900 dark:text-slate-100 mb-2">
                     Postgres extension installs

--- a/src/components/ui/HeroV3.tsx
+++ b/src/components/ui/HeroV3.tsx
@@ -3,7 +3,6 @@ import { documentation } from "@/lib/links";
 import Link from "next/link";
 import { Button } from "../Button";
 import LogoCloud from "./LogoCloud";
-import { siteConfig } from "@/app/siteConfig";
 import { HeroVisual } from "./HeroVisual";
 import { DarkModeOverlay } from "./DarkModeOverlay";
 import Code from "@/components/Code";

--- a/src/components/ui/HeroV3.tsx
+++ b/src/components/ui/HeroV3.tsx
@@ -33,13 +33,13 @@ export default async function HeroV3() {
           <div className="relative flex flex-col items-center justify-center sm:pt-48 pt-36 text-center px-6 sm:px-0">
             <div className="flex flex-col items-center w-full relative z-20">
               <Link
-                href={`${siteConfig.baseLinks.blog}/series-a-announcement`}
+                href="/customers/case-study-modern-treasury"
                 className="mb-6 mt-px ml-px inline-flex items-center h-[23px] w-[215px] justify-center border border-white/20 bg-white/10 px-1 text-xs font-medium text-white shadow-none transition-colors hover:bg-white/20 opacity-0 animate-hero-pill"
               >
                 <span className="mr-2 flex h-2 w-2">
                   <span className="relative inline-flex h-2 w-2 rounded-full bg-white"></span>
                 </span>
-                Announcing our $12M Series A
+                Modern Treasury case study
               </Link>
               <h1
                 id="hero-title"

--- a/src/components/ui/HeroV3.tsx
+++ b/src/components/ui/HeroV3.tsx
@@ -34,12 +34,12 @@ export default async function HeroV3() {
             <div className="flex flex-col items-center w-full relative z-20">
               <Link
                 href="/customers/case-study-modern-treasury"
-                className="mb-6 mt-px ml-px inline-flex items-center h-[23px] w-[215px] justify-center border border-white/20 bg-white/10 px-1 text-xs font-medium text-white shadow-none transition-colors hover:bg-white/20 opacity-0 animate-hero-pill"
+                className="mb-6 mt-px ml-px inline-flex items-center h-[23px] justify-center border border-white/20 bg-white/10 px-3 text-xs font-medium text-white shadow-none transition-colors hover:bg-white/20 opacity-0 animate-hero-pill"
               >
                 <span className="mr-2 flex h-2 w-2">
                   <span className="relative inline-flex h-2 w-2 rounded-full bg-white"></span>
                 </span>
-                Modern Treasury case study
+                ParadeDB Powers Modern Treasury&apos;s Core UI and Search APIs
               </Link>
               <h1
                 id="hero-title"

--- a/src/lib/links.ts
+++ b/src/lib/links.ts
@@ -4,8 +4,7 @@ export const company = {
 
 export const documentation = {
   BASE: "https://docs.paradedb.com/welcome/introduction",
-  GETTING_STARTED:
-    "https://docs.paradedb.com/documentation/getting-started/install",
+  GETTING_STARTED: "https://docs.paradedb.com/welcome/ai-agents",
   SEARCH: "https://docs.paradedb.com/documentation/full-text/overview",
   ANALYTICS: "https://docs.paradedb.com/documentation/aggregates/overview",
   REPLICATION:


### PR DESCRIPTION
# Ticket(s) Closed

None

## What

Bump the Postgres extension installs counter from `100K+` to `200K+` and align the DigitalOcean CTA label with the other cloud platforms.

## Why

The extension installs counter was stale. The DigitalOcean entry rendered a generic `Read Guide` CTA while Render and Railway used the `Deploy to <Platform>` pattern, so the cards looked inconsistent.

## How

**`src/components/ui/CommunityProof.tsx`**

- Updated extension installs stat: `100K+` → `200K+`.

**`src/components/ui/AgentReady.tsx`**

- Cloud Platforms CTA: replaced the DigitalOcean-specific `Read Guide` branch with the shared `Deploy to ${CloudPlatforms[selectedCloud].name}` label so all platforms render the same copy.

## Tests

- `pnpm run build` passes locally.
- Verified the homepage extension card shows `200K+` and the Cloud Platforms section shows `Deploy to DigitalOcean` when DigitalOcean is selected.