### PR TITLE
feat: Add Modern Treasury announcement banner above navbar

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,5 +1,6 @@
 import Footer from "@/components/ui/Footer";
 import { Navigation } from "@/components/ui/Navbar";
+import { SiteBanner } from "@/components/ui/SiteBanner";
 import type { Metadata } from "next";
 import { ThemeProvider } from "next-themes";
 import { Inter } from "next/font/google";
@@ -100,6 +101,7 @@ export default function RootLayout({
           attribute="class"
           enableSystem={true}
         >
+          <SiteBanner />
           <div className="relative mx-auto w-full max-w-[1440px]">
             <Navigation />
           </div>

--- a/src/components/ui/HeroV3.tsx
+++ b/src/components/ui/HeroV3.tsx
@@ -31,15 +31,6 @@ export default async function HeroV3() {
         <div className="px-4 md:px-12 w-full h-full flex flex-col flex-grow relative">
           <div className="relative flex flex-col items-center justify-center sm:pt-48 pt-36 text-center px-6 sm:px-0">
             <div className="flex flex-col items-center w-full relative z-20">
-              <Link
-                href="/customers/case-study-modern-treasury"
-                className="mb-6 mt-px ml-px inline-flex items-center h-[23px] justify-center border border-white/20 bg-white/10 px-3 text-xs font-medium text-white shadow-none transition-colors hover:bg-white/20 opacity-0 animate-hero-pill"
-              >
-                <span className="mr-2 flex h-2 w-2">
-                  <span className="relative inline-flex h-2 w-2 rounded-full bg-white"></span>
-                </span>
-                ParadeDB Powers Modern Treasury&apos;s Core UI and Search APIs
-              </Link>
               <h1
                 id="hero-title"
                 className="inline-block py-2 text-3xl font-bold tracking-tighter text-white sm:text-6xl opacity-0 animate-hero-title"

--- a/src/components/ui/SiteBanner.tsx
+++ b/src/components/ui/SiteBanner.tsx
@@ -5,7 +5,7 @@ export function SiteBanner() {
   return (
     <Link
       href="/customers/case-study-modern-treasury"
-      className="relative z-50 flex w-full items-center justify-center gap-2 bg-gradient-to-r from-indigo-700 via-indigo-600 to-indigo-700 px-4 py-2 text-center text-xs font-medium text-white transition-colors hover:from-indigo-600 hover:via-indigo-500 hover:to-indigo-600 sm:text-sm"
+      className="relative z-50 flex w-full items-center justify-center gap-2 bg-slate-900 px-4 py-2 text-center text-xs font-medium text-white transition-colors hover:bg-slate-800 sm:text-sm"
     >
       <span className="relative inline-flex h-2 w-2 shrink-0 rounded-full bg-white" />
       <span>

--- a/src/components/ui/SiteBanner.tsx
+++ b/src/components/ui/SiteBanner.tsx
@@ -1,0 +1,17 @@
+import Link from "next/link";
+import { RiArrowRightLine } from "@remixicon/react";
+
+export function SiteBanner() {
+  return (
+    <Link
+      href="/customers/case-study-modern-treasury"
+      className="relative z-50 flex w-full items-center justify-center gap-2 bg-gradient-to-r from-indigo-700 via-indigo-600 to-indigo-700 px-4 py-2 text-center text-xs font-medium text-white transition-colors hover:from-indigo-600 hover:via-indigo-500 hover:to-indigo-600 sm:text-sm"
+    >
+      <span className="relative inline-flex h-2 w-2 shrink-0 rounded-full bg-white" />
+      <span>
+        ParadeDB powers Modern Treasury&apos;s core UI and search APIs
+      </span>
+      <RiArrowRightLine className="size-4 shrink-0" />
+    </Link>
+  );
+}

--- a/src/components/ui/SiteBanner.tsx
+++ b/src/components/ui/SiteBanner.tsx
@@ -5,9 +5,9 @@ export function SiteBanner() {
   return (
     <Link
       href="/customers/case-study-modern-treasury"
-      className="relative z-50 flex w-full items-center justify-center gap-2 bg-slate-900 px-4 py-2 text-center text-xs font-medium text-white transition-colors hover:bg-slate-800 sm:text-sm"
+      className="relative z-50 flex w-full items-center justify-center gap-2 bg-slate-900 px-4 py-2 text-center text-xs font-medium text-white transition-colors hover:bg-slate-800 dark:bg-white dark:text-slate-900 dark:hover:bg-slate-100 sm:text-sm"
     >
-      <span className="relative inline-flex h-2 w-2 shrink-0 rounded-full bg-white" />
+      <span className="relative inline-flex h-2 w-2 shrink-0 rounded-full bg-white dark:bg-slate-900" />
       <span>
         ParadeDB powers Modern Treasury&apos;s core UI and search APIs
       </span>

--- a/src/components/ui/SiteBanner.tsx
+++ b/src/components/ui/SiteBanner.tsx
@@ -5,13 +5,15 @@ export function SiteBanner() {
   return (
     <Link
       href="/customers/case-study-modern-treasury"
-      className="relative z-50 flex w-full items-center justify-center gap-2 bg-indigo-950 px-4 py-2 text-center text-xs font-medium text-white transition-colors hover:bg-indigo-900 sm:text-sm"
+      className="group relative z-50 flex w-full items-center justify-center gap-3 bg-indigo-950 px-4 py-2 text-center text-xs font-medium text-white transition-colors hover:bg-indigo-900 sm:text-sm"
     >
-      <span className="relative inline-flex h-2 w-2 shrink-0 rounded-full bg-white" />
+      <span className="shrink-0 rounded-full bg-white/15 px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wider text-white sm:text-[11px]">
+        Case study
+      </span>
       <span>
         ParadeDB powers Modern Treasury&apos;s core UI and search APIs
       </span>
-      <RiArrowRightLine className="size-4 shrink-0" />
+      <RiArrowRightLine className="size-4 shrink-0 transition-transform group-hover:translate-x-0.5" />
     </Link>
   );
 }

--- a/src/components/ui/SiteBanner.tsx
+++ b/src/components/ui/SiteBanner.tsx
@@ -8,8 +8,7 @@ export function SiteBanner() {
       className="group relative z-50 flex w-full items-center justify-center gap-2 bg-indigo-950 px-4 py-2 text-center text-xs font-medium text-white transition-colors hover:bg-indigo-900 sm:text-sm"
     >
       <span>
-        <span className="text-white/60">Case study —</span> ParadeDB powers
-        Modern Treasury&apos;s core UI and search APIs
+        ParadeDB powers Modern Treasury&apos;s core UI and search APIs
       </span>
       <RiArrowRightLine className="size-4 shrink-0 transition-transform group-hover:translate-x-0.5" />
     </Link>

--- a/src/components/ui/SiteBanner.tsx
+++ b/src/components/ui/SiteBanner.tsx
@@ -5,9 +5,9 @@ export function SiteBanner() {
   return (
     <Link
       href="/customers/case-study-modern-treasury"
-      className="relative z-50 flex w-full items-center justify-center gap-2 bg-slate-900 px-4 py-2 text-center text-xs font-medium text-white transition-colors hover:bg-slate-800 dark:bg-white dark:text-slate-900 dark:hover:bg-slate-100 sm:text-sm"
+      className="relative z-50 flex w-full items-center justify-center gap-2 bg-amber-500 px-4 py-2 text-center text-xs font-medium text-slate-900 transition-colors hover:bg-amber-400 sm:text-sm"
     >
-      <span className="relative inline-flex h-2 w-2 shrink-0 rounded-full bg-white dark:bg-slate-900" />
+      <span className="relative inline-flex h-2 w-2 shrink-0 rounded-full bg-slate-900" />
       <span>
         ParadeDB powers Modern Treasury&apos;s core UI and search APIs
       </span>

--- a/src/components/ui/SiteBanner.tsx
+++ b/src/components/ui/SiteBanner.tsx
@@ -5,9 +5,9 @@ export function SiteBanner() {
   return (
     <Link
       href="/customers/case-study-modern-treasury"
-      className="relative z-50 flex w-full items-center justify-center gap-2 bg-amber-500 px-4 py-2 text-center text-xs font-medium text-slate-900 transition-colors hover:bg-amber-400 sm:text-sm"
+      className="relative z-50 flex w-full items-center justify-center gap-2 bg-indigo-950 px-4 py-2 text-center text-xs font-medium text-white transition-colors hover:bg-indigo-900 sm:text-sm"
     >
-      <span className="relative inline-flex h-2 w-2 shrink-0 rounded-full bg-slate-900" />
+      <span className="relative inline-flex h-2 w-2 shrink-0 rounded-full bg-white" />
       <span>
         ParadeDB powers Modern Treasury&apos;s core UI and search APIs
       </span>

--- a/src/components/ui/SiteBanner.tsx
+++ b/src/components/ui/SiteBanner.tsx
@@ -5,13 +5,11 @@ export function SiteBanner() {
   return (
     <Link
       href="/customers/case-study-modern-treasury"
-      className="group relative z-50 flex w-full items-center justify-center gap-3 bg-indigo-950 px-4 py-2 text-center text-xs font-medium text-white transition-colors hover:bg-indigo-900 sm:text-sm"
+      className="group relative z-50 flex w-full items-center justify-center gap-2 bg-indigo-950 px-4 py-2 text-center text-xs font-medium text-white transition-colors hover:bg-indigo-900 sm:text-sm"
     >
-      <span className="shrink-0 rounded-full bg-white/15 px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wider text-white sm:text-[11px]">
-        Case study
-      </span>
       <span>
-        ParadeDB powers Modern Treasury&apos;s core UI and search APIs
+        <span className="text-white/60">Case study —</span> ParadeDB powers
+        Modern Treasury&apos;s core UI and search APIs
       </span>
       <RiArrowRightLine className="size-4 shrink-0 transition-transform group-hover:translate-x-0.5" />
     </Link>


### PR DESCRIPTION
# Ticket(s) Closed

None

## What

Replace the in-hero announcement pill with a full-width site banner above the navbar that links to the Modern Treasury case study.

## Why

The pill is only visible on the homepage and gets buried inside the hero. A persistent banner above the navbar surfaces the case study on every page.

## How

**\`src/components/ui/SiteBanner.tsx\` (new)**

- Server component, full-width \`<Link>\` to \`/customers/case-study-modern-treasury\`.
- Indigo gradient background to match the brand, white text, white pulse dot, trailing arrow icon. Sits at \`z-50\` so it stays above the navbar visuals.

**\`src/app/layout.tsx\`**

- Import and render \`<SiteBanner />\` immediately above the navbar wrapper. Banner is the very first element inside the theme provider, so it appears on every route.

**\`src/components/ui/HeroV3.tsx\`**

- Removed the \"Announcing our \$12M Series A\" pill and the now-unused \`siteConfig\` import. The site banner supersedes it.
- Note: this also obviates the \"Modern Treasury case study\" pill change in #282 — that PR's HeroV3 change can be dropped.

## Tests

- \`pnpm run build\` passes
- \`pnpm run lint\` passes (8 pre-existing warnings, 0 errors)
- \`pnpm exec prettier --check \"src/**/*.{ts,tsx}\"\` passes
- \`pnpm run dev\`: visited \`http://localhost:3000/\`, banner renders above the navbar with the case study link