### PR TITLE
fix: Align callout icon with first line of text

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -556,8 +556,9 @@ a {
 /* Mintlify Callout icon vertical alignment to first text line */
 .mt-callout-icon-wrapper {
   display: flex;
-  align-items: flex-start !important;
+  align-items: center !important;
   padding-top: 0 !important;
+  height: calc(0.875rem * 1.5);
   flex-shrink: 0;
 }
 


### PR DESCRIPTION
# Ticket(s) Closed

None

## What

Vertically align the Mintlify-style callout icon with the first line of body text instead of the top of the content box.

## Why

The icon-wrapper had \`align-items: flex-start\` plus \`padding-top: 0\`, which parks the 16px icon at the top of the content box. With body text at 14px/1.5 line-height (21px tall), that puts the icon's vertical center 2.5px above the first line's vertical center, which reads as misaligned (visible in the TechCrunch callout on the Series A post). The icon should sit on the first line and stay there when the body wraps.

## How

**\`src/app/globals.css\` — \`.mt-callout-icon-wrapper\`**

- \`align-items: flex-start\` → \`align-items: center\` so the icon centers within its wrapper.
- Add \`height: calc(0.875rem * 1.5)\` to pin the wrapper to exactly one line of body text (font-size \`0.875rem\` × line-height \`1.5\`).

Net effect: the wrapper occupies the same vertical span as the first line, the icon centers inside it, and because the parent flex still uses \`align-items: flex-start\`, multi-line bodies leave the icon anchored to that first line.

## Tests

- \`pnpm run build\` passes
- \`pnpm run dev\`: rendered \`/blog/series-a-announcement\` and confirmed the \`mt-callout-icon-wrapper\` HTML reaches the page. Pixel alignment of the rendered icon to the first line should be eyeballed on the Vercel preview.