### PR TITLE
feat: Add SQLAlchemy docs link under Python framework card

### DIFF
--- a/src/components/ui/AgentReady.tsx
+++ b/src/components/ui/AgentReady.tsx
@@ -389,8 +389,8 @@ export default function AgentReady() {
                           </h3>
                           <p className="text-sm text-slate-600 dark:text-slate-400 mb-6 leading-relaxed">
                             Run ParadeDB on your preferred cloud platform.
-                            Supports Render, Railway, and DigitalOcean with more
-                            coming soon.
+                            Supports Railway, Render, and DigitalOcean, with
+                            more coming soon.
                           </p>
                           <Link
                             href={
@@ -530,7 +530,7 @@ export default function AgentReady() {
                           <p className="text-sm text-slate-600 dark:text-slate-400 mb-6 leading-relaxed">
                             Query ParadeDB from your favorite programming
                             language. Supports Django, SQLAlchemy, and
-                            ActiveRecord with more coming soon.
+                            ActiveRecord, with more coming soon.
                           </p>
                           <div className="mt-auto flex flex-wrap items-center gap-x-4 gap-y-2">
                             {Frameworks[selectedFramework].docs.map((doc) => (

--- a/src/components/ui/AgentReady.tsx
+++ b/src/components/ui/AgentReady.tsx
@@ -530,7 +530,7 @@ export default function AgentReady() {
                           <p className="text-sm text-slate-600 dark:text-slate-400 mb-6 leading-relaxed">
                             Query ParadeDB from your favorite programming
                             language. Supports Django, SQLAlchemy, and
-                            ActiveRecord, with more coming soon.
+                            ActiveRecord with more coming soon.
                           </p>
                           <div className="mt-auto flex flex-col gap-2">
                             {Frameworks[selectedFramework].docs.map((doc) => (

--- a/src/components/ui/AgentReady.tsx
+++ b/src/components/ui/AgentReady.tsx
@@ -532,7 +532,7 @@ export default function AgentReady() {
                             language. Supports Django, SQLAlchemy, and
                             ActiveRecord, with more coming soon.
                           </p>
-                          <div className="mt-auto flex flex-wrap items-center gap-x-4 gap-y-2">
+                          <div className="mt-auto flex flex-col gap-2">
                             {Frameworks[selectedFramework].docs.map((doc) => (
                               <Link
                                 key={doc.url}

--- a/src/components/ui/AgentReady.tsx
+++ b/src/components/ui/AgentReady.tsx
@@ -528,10 +528,11 @@ export default function AgentReady() {
                             Frameworks
                           </h3>
                           <p className="text-sm text-slate-600 dark:text-slate-400 mb-6 leading-relaxed">
-                            Query ParadeDB from Django, SQLAlchemy,
-                            ActiveRecord, and more.
+                            Query ParadeDB from your favorite programming
+                            language. Supports Django, SQLAlchemy, and
+                            ActiveRecord with more coming soon.
                           </p>
-                          <div className="mt-auto flex flex-col gap-2">
+                          <div className="mt-auto flex flex-wrap items-center gap-x-4 gap-y-2">
                             {Frameworks[selectedFramework].docs.map((doc) => (
                               <Link
                                 key={doc.url}

--- a/src/components/ui/AgentReady.tsx
+++ b/src/components/ui/AgentReady.tsx
@@ -528,9 +528,8 @@ export default function AgentReady() {
                             Frameworks
                           </h3>
                           <p className="text-sm text-slate-600 dark:text-slate-400 mb-6 leading-relaxed">
-                            Query ParadeDB from your favorite programming
-                            language. Supports Django, SQLAlchemy, and
-                            ActiveRecord with more coming soon.
+                            Query ParadeDB from Django, SQLAlchemy,
+                            ActiveRecord, and more.
                           </p>
                           <div className="mt-auto flex flex-col gap-2">
                             {Frameworks[selectedFramework].docs.map((doc) => (

--- a/src/components/ui/AgentReady.tsx
+++ b/src/components/ui/AgentReady.tsx
@@ -134,14 +134,28 @@ const Frameworks = [
   {
     name: "Python",
     className: "text-slate-900 dark:text-slate-100",
-    url: "https://docs.paradedb.com/documentation/getting-started/environment#django",
     icon: <PythonIcon className="size-[1.6rem]" />,
+    docs: [
+      {
+        label: "Django docs",
+        url: "https://docs.paradedb.com/documentation/getting-started/environment#django",
+      },
+      {
+        label: "SQLAlchemy docs",
+        url: "https://docs.paradedb.com/documentation/getting-started/environment#sqlalchemy",
+      },
+    ],
   },
   {
     name: "Ruby",
     className: "text-slate-900 dark:text-slate-100 -translate-y-[2px]",
-    url: "https://docs.paradedb.com/documentation/getting-started/environment#rails",
     icon: <RubyIcon className="size-[1.4rem]" />,
+    docs: [
+      {
+        label: "ActiveRecord docs",
+        url: "https://docs.paradedb.com/documentation/getting-started/environment#rails",
+      },
+    ],
   },
 ];
 
@@ -517,16 +531,19 @@ export default function AgentReady() {
                             Support for Django, SQLAlchemy, ActiveRecord and
                             more coming soon.
                           </p>
-                          <Link
-                            href={Frameworks[selectedFramework].url}
-                            target="_blank"
-                            className="mt-auto flex w-fit items-center gap-1 text-sm font-semibold text-indigo-600 dark:text-indigo-400 hover:text-indigo-700 dark:hover:text-indigo-300"
-                          >
-                            {Frameworks[selectedFramework].name === "Python"
-                              ? "Django docs"
-                              : "ActiveRecord docs"}
-                            <RiArrowRightLine className="size-4" />
-                          </Link>
+                          <div className="mt-auto flex flex-col gap-2">
+                            {Frameworks[selectedFramework].docs.map((doc) => (
+                              <Link
+                                key={doc.url}
+                                href={doc.url}
+                                target="_blank"
+                                className="flex w-fit items-center gap-1 text-sm font-semibold text-indigo-600 dark:text-indigo-400 hover:text-indigo-700 dark:hover:text-indigo-300"
+                              >
+                                {doc.label}
+                                <RiArrowRightLine className="size-4" />
+                              </Link>
+                            ))}
+                          </div>
                         </div>
                       </div>
                     </div>

--- a/src/components/ui/AgentReady.tsx
+++ b/src/components/ui/AgentReady.tsx
@@ -464,8 +464,8 @@ export default function AgentReady() {
                           </h3>
                           <p className="text-sm text-slate-600 dark:text-slate-400 mb-6 leading-relaxed">
                             Teach your agents to use ParadeDB with a single
-                            command. Works with Claude Code, Cursor, Codex,
-                            Windsurf, Gemini, and more.
+                            command. Works with Claude Code, Codex, Gemini,
+                            Cursor, Windsurf, and more.
                           </p>
                           <Link
                             href="https://docs.paradedb.com/welcome/ai-agents"

--- a/src/components/ui/AgentReady.tsx
+++ b/src/components/ui/AgentReady.tsx
@@ -528,8 +528,9 @@ export default function AgentReady() {
                             Frameworks
                           </h3>
                           <p className="text-sm text-slate-600 dark:text-slate-400 mb-6 leading-relaxed">
-                            Support for Django, SQLAlchemy, ActiveRecord and
-                            more coming soon.
+                            Query ParadeDB from your favorite programming
+                            language. Supports Django, SQLAlchemy, and
+                            ActiveRecord, with more coming soon.
                           </p>
                           <div className="mt-auto flex flex-col gap-2">
                             {Frameworks[selectedFramework].docs.map((doc) => (


### PR DESCRIPTION
# Ticket(s) Closed

None

## What

Surface a SQLAlchemy docs link alongside the existing Django one under the Python framework card on the homepage Frameworks section, while keeping the single Python logo.

## Why

The Frameworks copy already advertises \"Django, SQLAlchemy, ActiveRecord\", but only one CTA was rendered per language card. SQLAlchemy support had no entry point. Avoiding a separate Python card (with a duplicate Python logo) keeps the design clean and lets us add more Python ORMs later without visual clutter.

## How

**\`src/components/ui/AgentReady.tsx\` — \`Frameworks\` data**

- Replace the per-framework \`url: string\` with \`docs: { label, url }[]\`.
- Python entry now lists Django (\`environment#django\`) and SQLAlchemy (\`environment#sqlalchemy\`).
- Ruby entry keeps ActiveRecord (\`environment#rails\`).

**\`src/components/ui/AgentReady.tsx\` — Frameworks card render**

- Replace the single \`<Link>\` and the \`name === \"Python\" ? \"Django docs\" : \"ActiveRecord docs\"\` ternary with a \`Frameworks[selectedFramework].docs.map(...)\` that renders one stacked link per doc entry.
- CTA styling unchanged; links wrap in a \`flex-col gap-2\` container so multi-doc cards stack cleanly without affecting single-doc cards.

## Tests

- \`pnpm run build\` passes
- \`pnpm run lint\` passes (8 pre-existing warnings, 0 errors)
- \`pnpm exec prettier --check \"src/**/*.{ts,tsx}\"\` passes
- Will eyeball the Python card on the Vercel preview to confirm the Django and SQLAlchemy CTAs both render correctly