### PR TITLE
fix: Update ai-agents docs link to new path

### DIFF
--- a/src/components/ui/AgentReady.tsx
+++ b/src/components/ui/AgentReady.tsx
@@ -452,7 +452,7 @@ export default function AgentReady() {
                             Cursor, Windsurf, and more.
                           </p>
                           <Link
-                            href="https://docs.paradedb.com/welcome/ai-agents"
+                            href="https://docs.paradedb.com/documentation/getting-started/ai-agents"
                             target="_blank"
                             className="mt-auto flex w-fit items-center gap-1 text-sm font-semibold text-indigo-600 dark:text-indigo-400 hover:text-indigo-700 dark:hover:text-indigo-300"
                           >

--- a/src/lib/links.ts
+++ b/src/lib/links.ts
@@ -4,7 +4,8 @@ export const company = {
 
 export const documentation = {
   BASE: "https://docs.paradedb.com/welcome/introduction",
-  GETTING_STARTED: "https://docs.paradedb.com/documentation/getting-started/ai-agents",
+  GETTING_STARTED:
+    "https://docs.paradedb.com/documentation/getting-started/ai-agents",
   SEARCH: "https://docs.paradedb.com/documentation/full-text/overview",
   ANALYTICS: "https://docs.paradedb.com/documentation/aggregates/overview",
   REPLICATION:

--- a/src/lib/links.ts
+++ b/src/lib/links.ts
@@ -4,7 +4,7 @@ export const company = {
 
 export const documentation = {
   BASE: "https://docs.paradedb.com/welcome/introduction",
-  GETTING_STARTED: "https://docs.paradedb.com/welcome/ai-agents",
+  GETTING_STARTED: "https://docs.paradedb.com/documentation/getting-started/ai-agents",
   SEARCH: "https://docs.paradedb.com/documentation/full-text/overview",
   ANALYTICS: "https://docs.paradedb.com/documentation/aggregates/overview",
   REPLICATION:


### PR DESCRIPTION
## Summary
- The "Integrate with AI" docs page moved from `/welcome/ai-agents` to `/documentation/getting-started/ai-agents` (paradedb/paradedb#5016).
- Update the `GETTING_STARTED` link constant in `src/lib/links.ts` and the href in `AgentReady.tsx` to point at the new URL.

## Test plan
- [x] Click through "Integrate with AI" links on the landing page and verify they resolve to the new docs URL