### PR TITLE
feat: focus mode for articles

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -821,6 +821,28 @@ a {
   }
 }
 
+/* Focus mode: clean, centered reading view for articles */
+html.focus-mode header,
+html.focus-mode footer,
+html.focus-mode aside,
+html.focus-mode [data-focus-hide] {
+  display: none !important;
+}
+
+html.focus-mode main {
+  padding: 0 !important;
+}
+
+html.focus-mode article {
+  max-width: 72ch !important;
+  margin-left: auto !important;
+  margin-right: auto !important;
+  padding-top: 4rem !important;
+  padding-bottom: 4rem !important;
+  padding-left: 1.5rem !important;
+  padding-right: 1.5rem !important;
+}
+
 @layer utilities {
   .animate-hero-wrapper {
     animation: fade-in 500ms ease-out both;

--- a/src/components/ArticleActions.tsx
+++ b/src/components/ArticleActions.tsx
@@ -9,6 +9,7 @@ import {
   RiPerplexityFill,
   RiGithubFill,
 } from "@remixicon/react";
+import FocusMode from "@/components/FocusMode";
 
 interface ArticleActionsProps {
   basePath: string;
@@ -45,6 +46,9 @@ export default function ArticleActions({
   return (
     <div className="w-full">
       <ul className="space-y-0.5">
+        <li>
+          <FocusMode className={linkClass} />
+        </li>
         <li>
           <button
             onClick={handleCopyMarkdown}

--- a/src/components/ContentLayoutShell.tsx
+++ b/src/components/ContentLayoutShell.tsx
@@ -22,10 +22,7 @@ export function ContentLayoutShell({
       <div className="max-w-[1440px] mx-auto relative w-full">
         <section className="bg-white dark:bg-slate-950 flex flex-col relative">
           {/* Shaded Hatch Region below navbar */}
-          <div
-            data-focus-hide
-            className="px-4 md:px-12 w-full relative z-20"
-          >
+          <div data-focus-hide className="px-4 md:px-12 w-full relative z-20">
             <div className="h-8 md:h-12 w-full bg-diagonal-hatch border-b border-x border-slate-200 dark:border-slate-900 relative z-20 bg-slate-50/50 dark:bg-slate-900/50 opacity-60" />
           </div>
 
@@ -65,10 +62,7 @@ export function ContentLayoutShell({
           {bottomBar}
 
           {/* Shaded Hatch Region above footer */}
-          <div
-            data-focus-hide
-            className="px-4 md:px-12 w-full relative z-20"
-          >
+          <div data-focus-hide className="px-4 md:px-12 w-full relative z-20">
             <div className="h-8 md:h-12 w-full bg-diagonal-hatch border-t border-x border-slate-200 dark:border-slate-900 relative z-20 bg-slate-50/50 dark:bg-slate-900/50 opacity-60" />
           </div>
         </section>

--- a/src/components/ContentLayoutShell.tsx
+++ b/src/components/ContentLayoutShell.tsx
@@ -22,15 +22,24 @@ export function ContentLayoutShell({
       <div className="max-w-[1440px] mx-auto relative w-full">
         <section className="bg-white dark:bg-slate-950 flex flex-col relative">
           {/* Shaded Hatch Region below navbar */}
-          <div className="px-4 md:px-12 w-full relative z-20">
+          <div
+            data-focus-hide
+            className="px-4 md:px-12 w-full relative z-20"
+          >
             <div className="h-8 md:h-12 w-full bg-diagonal-hatch border-b border-x border-slate-200 dark:border-slate-900 relative z-20 bg-slate-50/50 dark:bg-slate-900/50 opacity-60" />
           </div>
 
           {topBar}
 
           {/* Outer Vertical Layout Borders */}
-          <div className="absolute inset-y-0 left-4 md:left-12 w-px bg-slate-200 dark:bg-slate-900 z-30 pointer-events-none" />
-          <div className="absolute inset-y-0 right-4 md:right-12 w-px bg-slate-200 dark:bg-slate-900 z-30 pointer-events-none" />
+          <div
+            data-focus-hide
+            className="absolute inset-y-0 left-4 md:left-12 w-px bg-slate-200 dark:bg-slate-900 z-30 pointer-events-none"
+          />
+          <div
+            data-focus-hide
+            className="absolute inset-y-0 right-4 md:right-12 w-px bg-slate-200 dark:bg-slate-900 z-30 pointer-events-none"
+          />
 
           {mobileNav}
 
@@ -56,7 +65,10 @@ export function ContentLayoutShell({
           {bottomBar}
 
           {/* Shaded Hatch Region above footer */}
-          <div className="px-4 md:px-12 w-full relative z-20">
+          <div
+            data-focus-hide
+            className="px-4 md:px-12 w-full relative z-20"
+          >
             <div className="h-8 md:h-12 w-full bg-diagonal-hatch border-t border-x border-slate-200 dark:border-slate-900 relative z-20 bg-slate-50/50 dark:bg-slate-900/50 opacity-60" />
           </div>
         </section>

--- a/src/components/ContentSidebar.tsx
+++ b/src/components/ContentSidebar.tsx
@@ -129,7 +129,10 @@ export function useContentSidebar({
   };
 
   const mobileNav = (
-    <div className="lg:hidden px-4 md:px-12 w-full relative z-30">
+    <div
+      data-focus-hide
+      className="lg:hidden px-4 md:px-12 w-full relative z-30"
+    >
       <div className="border-b border-slate-100 dark:border-slate-900">
         <button
           onClick={() => setMobileNavOpen(!mobileNavOpen)}
@@ -175,7 +178,10 @@ export function useContentSidebar({
   );
 
   const desktopSidebar = (
-    <div className="hidden lg:flex lg:w-80 lg:shrink-0 lg:flex-col transition-colors border-r border-slate-100 dark:border-slate-900">
+    <div
+      data-focus-hide
+      className="hidden lg:flex lg:w-80 lg:shrink-0 lg:flex-col transition-colors border-r border-slate-100 dark:border-slate-900"
+    >
       <div className="sticky top-0 max-h-screen overflow-y-auto flex flex-col gap-y-5 px-6 pt-8 pb-10">
         <nav className="flex flex-1 flex-col text-slate-900 dark:text-white">
           <div className="text-[10px] font-bold text-slate-500 dark:text-slate-400 uppercase tracking-[0.2em] mb-4 mt-0 px-2">

--- a/src/components/FocusMode.tsx
+++ b/src/components/FocusMode.tsx
@@ -1,0 +1,61 @@
+"use client";
+
+import { RiBookOpenLine, RiCloseLine } from "@remixicon/react";
+import { useEffect, useState } from "react";
+import { createPortal } from "react-dom";
+
+interface FocusModeProps {
+  className?: string;
+}
+
+export default function FocusMode({ className = "" }: FocusModeProps) {
+  const [active, setActive] = useState(false);
+  const [mounted, setMounted] = useState(false);
+
+  useEffect(() => {
+    setMounted(true);
+  }, []);
+
+  useEffect(() => {
+    const html = document.documentElement;
+    if (active) html.classList.add("focus-mode");
+    else html.classList.remove("focus-mode");
+    return () => html.classList.remove("focus-mode");
+  }, [active]);
+
+  useEffect(() => {
+    if (!active) return;
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") setActive(false);
+    };
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [active]);
+
+  return (
+    <>
+      <button
+        type="button"
+        onClick={() => setActive(true)}
+        className={`${className} w-full`}
+      >
+        <RiBookOpenLine size={16} className="shrink-0" />
+        Read in focus mode
+      </button>
+      {mounted &&
+        active &&
+        createPortal(
+          <button
+            type="button"
+            onClick={() => setActive(false)}
+            aria-label="Exit focus mode (Esc)"
+            className="fixed top-4 right-4 z-[60] flex items-center gap-2 rounded-md border border-slate-200 dark:border-slate-800 bg-white/90 dark:bg-slate-900/90 backdrop-blur px-3 py-2 text-sm font-medium text-slate-600 dark:text-slate-400 hover:text-indigo-600 dark:hover:text-indigo-400 shadow-sm transition-colors"
+          >
+            <RiCloseLine size={16} className="shrink-0" />
+            Exit focus mode
+          </button>,
+          document.body,
+        )}
+    </>
+  );
+}

--- a/src/components/PrevNextBar.tsx
+++ b/src/components/PrevNextBar.tsx
@@ -20,7 +20,7 @@ export function PrevNextBar({
   if (!previousHref && !nextHref) return null;
 
   return (
-    <div className="px-4 md:px-12 w-full relative z-30">
+    <div data-focus-hide className="px-4 md:px-12 w-full relative z-30">
       <div
         className={`${position === "top" ? "border-b h-12" : "border-t h-16"} border-slate-100 dark:border-slate-900 flex justify-between items-center px-6`}
       >


### PR DESCRIPTION
# Ticket(s) Closed

None

## What

Adds a "Read in focus mode" toggle to the article actions sidebar that reflows blog and customer pages into a centered, distraction-free reading column.

## Why

We tried this before (#291) but reverted it (`c58857f`) because the implementation overlaid white panels around the existing layout — content stayed left-anchored next to its sidebar, so it looked like "half the page disappeared" rather than a true reader view. This version reflows the layout instead of masking it: chrome elements are hidden via CSS and the `<article>` is recentered at a comfortable reading width.

## How

**New component `src/components/FocusMode.tsx`**
- Toggles a `focus-mode` class on `<html>` rather than rendering an overlay.
- Inline trigger button (rendered in `ArticleActions`) enters focus mode.
- A floating "Exit focus mode" button is portaled into `<body>` so it remains visible after the sidebar is hidden; `Escape` also exits.
- No more `ResizeObserver`, scroll/resize listeners, or bounding-box math — the previous PR's approach.

**Wired into actions sidebar `src/components/ArticleActions.tsx`**
- `FocusMode` is the first item in the actions list, above `Copy markdown`.

**CSS `src/app/globals.css`**
- `html.focus-mode header, footer, aside, [data-focus-hide]` → `display: none`.
- `html.focus-mode main` → padding zeroed.
- `html.focus-mode article` → `max-width: 72ch`, centered with `margin-inline: auto` and added vertical/horizontal padding for breathing room.

**Marked layout chrome with `data-focus-hide`**
- `src/components/ContentLayoutShell.tsx` — both diagonal-hatch decoration rows and the two vertical border lines.
- `src/components/PrevNextBar.tsx` — root wrapper (covers top + bottom prev/next bars).
- `src/components/ContentSidebar.tsx` — `mobileNav` and `desktopSidebar` wrappers.

Global `<header>` (Navbar) and `<footer>` (Footer) are hidden via tag selectors, and `<aside>` covers the in-article TOC + actions sidebar.

## Tests

- `npx tsc --noEmit` passes with no errors.
- `npm run dev` starts cleanly; `/blog/introducing-paradedb` returns `200` with no console errors.
- Manual verification on a blog post at ≥`xl` width:
  - Clicking `Read in focus mode` hides the navbar, footer, prev/next bars, hatch decorations, vertical borders, blog list sidebar, and TOC/actions sidebar.
  - `<article>` recenters in a ~72ch column.
  - Floating "Exit focus mode" button (top-right) and `Esc` both return to the normal view.