### PR TITLE
fix: prevent color flash on theme toggle

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -100,6 +100,7 @@ export default function RootLayout({
           defaultTheme="system"
           attribute="class"
           enableSystem={true}
+          disableTransitionOnChange
         >
           <SiteBanner />
           <div className="relative mx-auto w-full max-w-[1440px]">


### PR DESCRIPTION
# Ticket(s) Closed

None

## What

Pass `disableTransitionOnChange` to the `next-themes` `ThemeProvider` so the dark/light swap is instantaneous.

## Why

When toggling between dark and light modes, side dividers (e.g. the vertical bars in `AgentReady.tsx`, `CommunityProof.tsx`, `HowItWorks.tsx`) and other surfaces briefly retained the previous theme's color for ~half a second before settling. The dividers themselves don't declare a transition, but the codebase applies `transition-all` / `transition-colors` broadly (including a global rule on every `<a>` in `globals.css:518`, plus many `transition-all` / `transition-colors duration-300` / `duration-500` utilities across UI components). When `next-themes` flips the `.dark` class on `<html>`, those inherited transitions animated `background-color` from old → new instead of snapping, producing the flash.

## How

**`src/app/layout.tsx`**

- Added `disableTransitionOnChange` to `<ThemeProvider>`. `next-themes` now injects a temporary `* { transition: none !important }` rule for the duration of the class swap, so all theme-driven color changes happen in the same frame.

## Tests

- `pnpm run build` passes
- Toggled between system / light / dark in the navbar `ThemeToggle` and verified the side dividers and page chrome snap to the new theme without retaining the prior color