### PR TITLE
chore: Update llms.txt with recent blog and learn entries

### DIFF
--- a/.github/workflows/check-llms-txt.yml
+++ b/.github/workflows/check-llms-txt.yml
@@ -1,0 +1,78 @@
+# workflows/check-llms-txt.yml
+#
+# Check llms.txt Coverage
+# Ensure every blog post, customer case study, and learn page is listed in public/llms.txt.
+
+name: Check llms.txt Coverage
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+    paths:
+      - "src/app/blog/**"
+      - "src/app/customers/**"
+      - "src/app/learn/**"
+      - "public/llms.txt"
+      - ".github/workflows/check-llms-txt.yml"
+  workflow_dispatch:
+
+concurrency:
+  group: check-llms-txt-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  check-llms-txt:
+    name: Check llms.txt Coverage
+    runs-on: ubuntu-latest
+    if: github.event.pull_request.draft == false
+
+    steps:
+      - name: Checkout Git Repository
+        uses: actions/checkout@v6
+
+      - name: Check for missing llms.txt entries
+        run: |
+          missing=0
+          llms_file="public/llms.txt"
+
+          if [ ! -f "$llms_file" ]; then
+            echo "::error::$llms_file not found"
+            exit 1
+          fi
+
+          check_url() {
+            local path="$1"
+            local url="https://www.paradedb.com${path}"
+            if ! grep -qF "($url)" "$llms_file"; then
+              echo "::error::Missing entry in $llms_file for $url"
+              missing=1
+            fi
+          }
+
+          # Blog posts and customer case studies: one metadata.json per slug.
+          for dir in src/app/blog/*/metadata.json src/app/customers/*/metadata.json; do
+            [ -f "$dir" ] || continue
+            slug=$(basename "$(dirname "$dir")")
+            section=$(basename "$(dirname "$(dirname "$dir")")")
+            check_url "/${section}/${slug}"
+          done
+
+          # Learn pages: nested under category directories, identified by page.tsx.
+          while IFS= read -r page; do
+            rel="${page#src/app}"
+            url_path="${rel%/page.tsx}"
+            # Skip the /learn landing page itself.
+            if [ "$url_path" = "/learn" ]; then
+              continue
+            fi
+            check_url "$url_path"
+          done < <(find src/app/learn -type f -name page.tsx)
+
+          if [ "$missing" -eq 1 ]; then
+            echo ""
+            echo "Every blog post, customer case study, and learn page must be listed in $llms_file."
+            echo "Add a markdown link in the form: - [Title](https://www.paradedb.com/<path>)"
+            exit 1
+          fi
+
+          echo "All blog, customer, and learn pages are listed in $llms_file."

--- a/public/llms.txt
+++ b/public/llms.txt
@@ -12,6 +12,10 @@
 
 ## Blog
 
+- [ParadeDB is Officially on Render](https://www.paradedb.com/blog/render)
+- [What We Think About When We Think About Benchmarking](https://www.paradedb.com/blog/what-we-think-about-when-we-think-about-benchmarking)
+- [ParadeDB is Officially on Railway](https://www.paradedb.com/blog/railway)
+- [A Conversation with Paul Masurel, Creator of Tantivy](https://www.paradedb.com/blog/tantivy-interview)
 - [How We Optimized Top K in Postgres](https://www.paradedb.com/blog/optimizing-top-k)
 - [Retrieve and Rerank: Personalized Search Without Leaving Postgres](https://www.paradedb.com/blog/personalized-search-in-postgresql)
 - [Hybrid Search in PostgreSQL: The Missing Manual](https://www.paradedb.com/blog/hybrid-search-in-postgresql-the-missing-manual)
@@ -53,6 +57,8 @@
 - [What is Vector Search?](https://www.paradedb.com/learn/search-concepts/vector-search)
 - [What is Hybrid Search?](https://www.paradedb.com/learn/search-concepts/hybrid-search)
 - [What is Faceted Search?](https://www.paradedb.com/learn/search-concepts/faceting)
+- [What is Block WAND?](https://www.paradedb.com/learn/search-concepts/block-wand)
 - [Full-Text Search in PostgreSQL](https://www.paradedb.com/learn/search-in-postgresql/full-text-search)
 - [Implementing BM25 in PostgreSQL](https://www.paradedb.com/learn/search-in-postgresql/bm25)
+- [What is pgrx?](https://www.paradedb.com/learn/postgresql/what-is-pgrx)
 - [Introduction to Tantivy](https://www.paradedb.com/learn/tantivy/introduction)


### PR DESCRIPTION
# Ticket(s) Closed

None

## What

Adds six entries to `public/llms.txt` that were published since it was last updated.

## Why

`llms.txt` is hand-maintained (unlike `sitemap.xml`, which `next-sitemap` regenerates on build), so new blog posts, case studies, and learn pages need to be added explicitly. Six recently merged pages were missing.

## How

**`public/llms.txt`**

- Blog section — prepended (reverse-chronological):
  - `render` — ParadeDB is Officially on Render
  - `what-we-think-about-when-we-think-about-benchmarking` — What We Think About When We Think About Benchmarking
  - `railway` — ParadeDB is Officially on Railway
  - `tantivy-interview` — A Conversation with Paul Masurel, Creator of Tantivy
- Learn section:
  - Added `search-concepts/block-wand` — What is Block WAND?
  - Added `postgresql/what-is-pgrx` — What is pgrx?

No customers were missing.

## Tests

- Plain-text file change; no build required.
- Verified each new URL maps to an existing `src/app/.../page.tsx` and `metadata.json`.