### PR TITLE
fix: prevent GitHub logo pop-in on navbar load

### DIFF
--- a/src/components/ui/Navbar.tsx
+++ b/src/components/ui/Navbar.tsx
@@ -245,9 +245,10 @@ export function Navigation() {
               <Link
                 href={github.REPO}
                 target="_blank"
+                aria-label="GitHub repository"
                 className={cx(
                   "items-center justify-center space-x-2 transition-all duration-300",
-                  stars && !open ? "flex opacity-100" : "hidden opacity-0",
+                  open ? "hidden opacity-0" : "flex opacity-100",
                 )}
               >
                 <RiGithubFill
@@ -261,11 +262,13 @@ export function Navigation() {
                 />
                 <div
                   className={cx(
-                    "text-sm font-medium transition-colors",
+                    "text-sm font-medium transition-opacity duration-300",
                     isHomePage && !open
                       ? "text-white"
                       : "text-slate-900 dark:text-slate-100",
+                    stars ? "opacity-100" : "opacity-0",
                   )}
+                  aria-hidden={stars ? undefined : true}
                 >
                   {formatStarCount(stars ?? 0)}
                 </div>


### PR DESCRIPTION
# Ticket(s) Closed

None

## What

Render the navbar GitHub link immediately instead of waiting for the GitHub API star-count response.

## Why

In `src/components/ui/Navbar.tsx`, the GitHub link was hidden (`hidden opacity-0`) until the `stars` state was populated by the `fetch(github.API)` call. On slow connections, this fetch resolves noticeably later than the rest of the navbar renders, causing the GitHub icon to pop in a few hundred milliseconds after the other elements.

## How

**`src/components/ui/Navbar.tsx`**

- Changed the GitHub `<Link>` visibility condition from `stars && !open ? "flex opacity-100" : "hidden opacity-0"` → `open ? "hidden opacity-0" : "flex opacity-100"` so the icon renders as soon as the navbar mounts.
- Moved the loading state to the star-count `<div>` only: it stays `opacity-0` until `stars` resolves, then fades in via `transition-opacity duration-300`.
- Marked the count `aria-hidden` while the value is unresolved so screen readers don't announce a placeholder `0`.
- Added `aria-label="GitHub repository"` on the link since the visible text is no longer guaranteed to be present at mount.

## Tests

- `pnpm run build` passes.
- Verified locally with Chrome DevTools network throttling (Slow 3G): GitHub icon now appears with the rest of the navbar, and the star count fades in once the API responds.
- Verified the mobile menu open state still hides the GitHub link as before.