### PR TITLE
feat: Add structured data, AI crawler rules, and agent discovery signals

### DIFF
--- a/next-sitemap.config.js
+++ b/next-sitemap.config.js
@@ -108,6 +108,27 @@ module.exports = {
   ],
   robotsTxtOptions: {
     additionalSitemaps: ["https://docs.paradedb.com/sitemap.xml"],
+    // Explicitly welcome reputable AI/agent crawlers. The wildcard policy
+    // already allows everyone; naming these is a discoverability signal that
+    // the site is intentionally open to agents.
+    policies: [
+      { userAgent: "*", allow: "/" },
+      { userAgent: "GPTBot", allow: "/" },
+      { userAgent: "OAI-SearchBot", allow: "/" },
+      { userAgent: "ChatGPT-User", allow: "/" },
+      { userAgent: "ClaudeBot", allow: "/" },
+      { userAgent: "Claude-User", allow: "/" },
+      { userAgent: "anthropic-ai", allow: "/" },
+      { userAgent: "PerplexityBot", allow: "/" },
+      { userAgent: "Perplexity-User", allow: "/" },
+      { userAgent: "Google-Extended", allow: "/" },
+      { userAgent: "Applebot-Extended", allow: "/" },
+      { userAgent: "Amazonbot", allow: "/" },
+      { userAgent: "Meta-ExternalAgent", allow: "/" },
+      { userAgent: "DuckAssistBot", allow: "/" },
+      { userAgent: "cohere-ai", allow: "/" },
+      { userAgent: "CCBot", allow: "/" },
+    ],
   },
   /**
    * Per-path overrides for priority, changefreq, and lastmod.

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -30,6 +30,23 @@ const nextConfig = {
     ];
   },
 
+  async headers() {
+    return [
+      {
+        // Advertise the LLM-friendly site index on every response so agents
+        // can discover it without guessing the /llms.txt path.
+        source: "/:path*",
+        headers: [
+          {
+            key: "Link",
+            value:
+              '</llms.txt>; rel="llms"; type="text/markdown"; title="ParadeDB llms.txt"',
+          },
+        ],
+      },
+    ];
+  },
+
   async redirects() {
     return [
       // --- host-based redirects (put first) ---

--- a/public/.well-known/security.txt
+++ b/public/.well-known/security.txt
@@ -1,0 +1,5 @@
+Contact: mailto:security@paradedb.com
+Policy: https://github.com/paradedb/paradedb/blob/main/SECURITY.md
+Canonical: https://www.paradedb.com/.well-known/security.txt
+Preferred-Languages: en
+Expires: 2027-05-21T00:00:00.000Z

--- a/src/app/blog/agpl/layout.tsx
+++ b/src/app/blog/agpl/layout.tsx
@@ -1,10 +1,16 @@
 import type { Metadata } from "next";
 import { generateBlogMetadata } from "@/lib/blog-metadata";
+import { ArticleJsonLd } from "@/components/ArticleJsonLd";
 
 export async function generateMetadata(): Promise<Metadata> {
   return generateBlogMetadata(__dirname);
 }
 
 export default function Layout({ children }: { children: React.ReactNode }) {
-  return children;
+  return (
+    <>
+      <ArticleJsonLd dirPath={__dirname} />
+      {children}
+    </>
+  );
 }

--- a/src/app/blog/block-storage-part-one/layout.tsx
+++ b/src/app/blog/block-storage-part-one/layout.tsx
@@ -1,10 +1,16 @@
 import type { Metadata } from "next";
 import { generateBlogMetadata } from "@/lib/blog-metadata";
+import { ArticleJsonLd } from "@/components/ArticleJsonLd";
 
 export async function generateMetadata(): Promise<Metadata> {
   return generateBlogMetadata(__dirname);
 }
 
 export default function Layout({ children }: { children: React.ReactNode }) {
-  return children;
+  return (
+    <>
+      <ArticleJsonLd dirPath={__dirname} />
+      {children}
+    </>
+  );
 }

--- a/src/app/blog/elasticsearch-acid-test/layout.tsx
+++ b/src/app/blog/elasticsearch-acid-test/layout.tsx
@@ -1,10 +1,16 @@
 import type { Metadata } from "next";
 import { generateBlogMetadata } from "@/lib/blog-metadata";
+import { ArticleJsonLd } from "@/components/ArticleJsonLd";
 
 export async function generateMetadata(): Promise<Metadata> {
   return generateBlogMetadata(__dirname);
 }
 
 export default function Layout({ children }: { children: React.ReactNode }) {
-  return children;
+  return (
+    <>
+      <ArticleJsonLd dirPath={__dirname} />
+      {children}
+    </>
+  );
 }

--- a/src/app/blog/elasticsearch-vs-postgres/layout.tsx
+++ b/src/app/blog/elasticsearch-vs-postgres/layout.tsx
@@ -1,10 +1,16 @@
 import type { Metadata } from "next";
 import { generateBlogMetadata } from "@/lib/blog-metadata";
+import { ArticleJsonLd } from "@/components/ArticleJsonLd";
 
 export async function generateMetadata(): Promise<Metadata> {
   return generateBlogMetadata(__dirname);
 }
 
 export default function Layout({ children }: { children: React.ReactNode }) {
-  return children;
+  return (
+    <>
+      <ArticleJsonLd dirPath={__dirname} />
+      {children}
+    </>
+  );
 }

--- a/src/app/blog/elasticsearch-was-never-a-database/layout.tsx
+++ b/src/app/blog/elasticsearch-was-never-a-database/layout.tsx
@@ -1,10 +1,16 @@
 import type { Metadata } from "next";
 import { generateBlogMetadata } from "@/lib/blog-metadata";
+import { ArticleJsonLd } from "@/components/ArticleJsonLd";
 
 export async function generateMetadata(): Promise<Metadata> {
   return generateBlogMetadata(__dirname);
 }
 
 export default function Layout({ children }: { children: React.ReactNode }) {
-  return children;
+  return (
+    <>
+      <ArticleJsonLd dirPath={__dirname} />
+      {children}
+    </>
+  );
 }

--- a/src/app/blog/etl-vs-logical-replication/layout.tsx
+++ b/src/app/blog/etl-vs-logical-replication/layout.tsx
@@ -1,10 +1,16 @@
 import type { Metadata } from "next";
 import { generateBlogMetadata } from "@/lib/blog-metadata";
+import { ArticleJsonLd } from "@/components/ArticleJsonLd";
 
 export async function generateMetadata(): Promise<Metadata> {
   return generateBlogMetadata(__dirname);
 }
 
 export default function Layout({ children }: { children: React.ReactNode }) {
-  return children;
+  return (
+    <>
+      <ArticleJsonLd dirPath={__dirname} />
+      {children}
+    </>
+  );
 }

--- a/src/app/blog/faceting/layout.tsx
+++ b/src/app/blog/faceting/layout.tsx
@@ -1,10 +1,16 @@
 import type { Metadata } from "next";
 import { generateBlogMetadata } from "@/lib/blog-metadata";
+import { ArticleJsonLd } from "@/components/ArticleJsonLd";
 
 export async function generateMetadata(): Promise<Metadata> {
   return generateBlogMetadata(__dirname);
 }
 
 export default function Layout({ children }: { children: React.ReactNode }) {
-  return children;
+  return (
+    <>
+      <ArticleJsonLd dirPath={__dirname} />
+      {children}
+    </>
+  );
 }

--- a/src/app/blog/hybrid-search-in-postgresql-the-missing-manual/layout.tsx
+++ b/src/app/blog/hybrid-search-in-postgresql-the-missing-manual/layout.tsx
@@ -1,10 +1,16 @@
 import type { Metadata } from "next";
 import { generateBlogMetadata } from "@/lib/blog-metadata";
+import { ArticleJsonLd } from "@/components/ArticleJsonLd";
 
 export async function generateMetadata(): Promise<Metadata> {
   return generateBlogMetadata(__dirname);
 }
 
 export default function Layout({ children }: { children: React.ReactNode }) {
-  return children;
+  return (
+    <>
+      <ArticleJsonLd dirPath={__dirname} />
+      {children}
+    </>
+  );
 }

--- a/src/app/blog/increased-write-performance/layout.tsx
+++ b/src/app/blog/increased-write-performance/layout.tsx
@@ -1,10 +1,16 @@
 import type { Metadata } from "next";
 import { generateBlogMetadata } from "@/lib/blog-metadata";
+import { ArticleJsonLd } from "@/components/ArticleJsonLd";
 
 export async function generateMetadata(): Promise<Metadata> {
   return generateBlogMetadata(__dirname);
 }
 
 export default function Layout({ children }: { children: React.ReactNode }) {
-  return children;
+  return (
+    <>
+      <ArticleJsonLd dirPath={__dirname} />
+      {children}
+    </>
+  );
 }

--- a/src/app/blog/introducing-paradedb/layout.tsx
+++ b/src/app/blog/introducing-paradedb/layout.tsx
@@ -1,10 +1,16 @@
 import type { Metadata } from "next";
 import { generateBlogMetadata } from "@/lib/blog-metadata";
+import { ArticleJsonLd } from "@/components/ArticleJsonLd";
 
 export async function generateMetadata(): Promise<Metadata> {
   return generateBlogMetadata(__dirname);
 }
 
 export default function Layout({ children }: { children: React.ReactNode }) {
-  return children;
+  return (
+    <>
+      <ArticleJsonLd dirPath={__dirname} />
+      {children}
+    </>
+  );
 }

--- a/src/app/blog/introducing-search/layout.tsx
+++ b/src/app/blog/introducing-search/layout.tsx
@@ -1,10 +1,16 @@
 import type { Metadata } from "next";
 import { generateBlogMetadata } from "@/lib/blog-metadata";
+import { ArticleJsonLd } from "@/components/ArticleJsonLd";
 
 export async function generateMetadata(): Promise<Metadata> {
   return generateBlogMetadata(__dirname);
 }
 
 export default function Layout({ children }: { children: React.ReactNode }) {
-  return children;
+  return (
+    <>
+      <ArticleJsonLd dirPath={__dirname} />
+      {children}
+    </>
+  );
 }

--- a/src/app/blog/introducing-sparse/layout.tsx
+++ b/src/app/blog/introducing-sparse/layout.tsx
@@ -1,10 +1,16 @@
 import type { Metadata } from "next";
 import { generateBlogMetadata } from "@/lib/blog-metadata";
+import { ArticleJsonLd } from "@/components/ArticleJsonLd";
 
 export async function generateMetadata(): Promise<Metadata> {
   return generateBlogMetadata(__dirname);
 }
 
 export default function Layout({ children }: { children: React.ReactNode }) {
-  return children;
+  return (
+    <>
+      <ArticleJsonLd dirPath={__dirname} />
+      {children}
+    </>
+  );
 }

--- a/src/app/blog/lsm-trees-in-postgres/layout.tsx
+++ b/src/app/blog/lsm-trees-in-postgres/layout.tsx
@@ -1,10 +1,16 @@
 import type { Metadata } from "next";
 import { generateBlogMetadata } from "@/lib/blog-metadata";
+import { ArticleJsonLd } from "@/components/ArticleJsonLd";
 
 export async function generateMetadata(): Promise<Metadata> {
   return generateBlogMetadata(__dirname);
 }
 
 export default function Layout({ children }: { children: React.ReactNode }) {
-  return children;
+  return (
+    <>
+      <ArticleJsonLd dirPath={__dirname} />
+      {children}
+    </>
+  );
 }

--- a/src/app/blog/optimizing-top-k/layout.tsx
+++ b/src/app/blog/optimizing-top-k/layout.tsx
@@ -1,10 +1,16 @@
 import type { Metadata } from "next";
 import { generateBlogMetadata } from "@/lib/blog-metadata";
+import { ArticleJsonLd } from "@/components/ArticleJsonLd";
 
 export async function generateMetadata(): Promise<Metadata> {
   return generateBlogMetadata(__dirname);
 }
 
 export default function Layout({ children }: { children: React.ReactNode }) {
-  return children;
+  return (
+    <>
+      <ArticleJsonLd dirPath={__dirname} />
+      {children}
+    </>
+  );
 }

--- a/src/app/blog/paradedb-0-20-0/layout.tsx
+++ b/src/app/blog/paradedb-0-20-0/layout.tsx
@@ -1,10 +1,16 @@
 import type { Metadata } from "next";
 import { generateBlogMetadata } from "@/lib/blog-metadata";
+import { ArticleJsonLd } from "@/components/ArticleJsonLd";
 
 export async function generateMetadata(): Promise<Metadata> {
   return generateBlogMetadata(__dirname);
 }
 
 export default function Layout({ children }: { children: React.ReactNode }) {
-  return children;
+  return (
+    <>
+      <ArticleJsonLd dirPath={__dirname} />
+      {children}
+    </>
+  );
 }

--- a/src/app/blog/personalized-search-in-postgresql/layout.tsx
+++ b/src/app/blog/personalized-search-in-postgresql/layout.tsx
@@ -1,10 +1,16 @@
 import type { Metadata } from "next";
 import { generateBlogMetadata } from "@/lib/blog-metadata";
+import { ArticleJsonLd } from "@/components/ArticleJsonLd";
 
 export async function generateMetadata(): Promise<Metadata> {
   return generateBlogMetadata(__dirname);
 }
 
 export default function Layout({ children }: { children: React.ReactNode }) {
-  return children;
+  return (
+    <>
+      <ArticleJsonLd dirPath={__dirname} />
+      {children}
+    </>
+  );
 }

--- a/src/app/blog/railway/layout.tsx
+++ b/src/app/blog/railway/layout.tsx
@@ -1,10 +1,16 @@
 import type { Metadata } from "next";
 import { generateBlogMetadata } from "@/lib/blog-metadata";
+import { ArticleJsonLd } from "@/components/ArticleJsonLd";
 
 export async function generateMetadata(): Promise<Metadata> {
   return generateBlogMetadata(__dirname);
 }
 
 export default function Layout({ children }: { children: React.ReactNode }) {
-  return children;
+  return (
+    <>
+      <ArticleJsonLd dirPath={__dirname} />
+      {children}
+    </>
+  );
 }

--- a/src/app/blog/rebrand/layout.tsx
+++ b/src/app/blog/rebrand/layout.tsx
@@ -1,10 +1,16 @@
 import type { Metadata } from "next";
 import { generateBlogMetadata } from "@/lib/blog-metadata";
+import { ArticleJsonLd } from "@/components/ArticleJsonLd";
 
 export async function generateMetadata(): Promise<Metadata> {
   return generateBlogMetadata(__dirname);
 }
 
 export default function Layout({ children }: { children: React.ReactNode }) {
-  return children;
+  return (
+    <>
+      <ArticleJsonLd dirPath={__dirname} />
+      {children}
+    </>
+  );
 }

--- a/src/app/blog/render/layout.tsx
+++ b/src/app/blog/render/layout.tsx
@@ -1,10 +1,16 @@
 import type { Metadata } from "next";
 import { generateBlogMetadata } from "@/lib/blog-metadata";
+import { ArticleJsonLd } from "@/components/ArticleJsonLd";
 
 export async function generateMetadata(): Promise<Metadata> {
   return generateBlogMetadata(__dirname);
 }
 
 export default function Layout({ children }: { children: React.ReactNode }) {
-  return children;
+  return (
+    <>
+      <ArticleJsonLd dirPath={__dirname} />
+      {children}
+    </>
+  );
 }

--- a/src/app/blog/series-a-announcement/layout.tsx
+++ b/src/app/blog/series-a-announcement/layout.tsx
@@ -1,10 +1,16 @@
 import type { Metadata } from "next";
 import { generateBlogMetadata } from "@/lib/blog-metadata";
+import { ArticleJsonLd } from "@/components/ArticleJsonLd";
 
 export async function generateMetadata(): Promise<Metadata> {
   return generateBlogMetadata(__dirname);
 }
 
 export default function Layout({ children }: { children: React.ReactNode }) {
-  return children;
+  return (
+    <>
+      <ArticleJsonLd dirPath={__dirname} />
+      {children}
+    </>
+  );
 }

--- a/src/app/blog/tantivy-interview/layout.tsx
+++ b/src/app/blog/tantivy-interview/layout.tsx
@@ -1,10 +1,16 @@
 import type { Metadata } from "next";
 import { generateBlogMetadata } from "@/lib/blog-metadata";
+import { ArticleJsonLd } from "@/components/ArticleJsonLd";
 
 export async function generateMetadata(): Promise<Metadata> {
   return generateBlogMetadata(__dirname);
 }
 
 export default function Layout({ children }: { children: React.ReactNode }) {
-  return children;
+  return (
+    <>
+      <ArticleJsonLd dirPath={__dirname} />
+      {children}
+    </>
+  );
 }

--- a/src/app/blog/v2api/layout.tsx
+++ b/src/app/blog/v2api/layout.tsx
@@ -1,10 +1,16 @@
 import type { Metadata } from "next";
 import { generateBlogMetadata } from "@/lib/blog-metadata";
+import { ArticleJsonLd } from "@/components/ArticleJsonLd";
 
 export async function generateMetadata(): Promise<Metadata> {
   return generateBlogMetadata(__dirname);
 }
 
 export default function Layout({ children }: { children: React.ReactNode }) {
-  return children;
+  return (
+    <>
+      <ArticleJsonLd dirPath={__dirname} />
+      {children}
+    </>
+  );
 }

--- a/src/app/blog/what-we-think-about-when-we-think-about-benchmarking/layout.tsx
+++ b/src/app/blog/what-we-think-about-when-we-think-about-benchmarking/layout.tsx
@@ -1,10 +1,16 @@
 import type { Metadata } from "next";
 import { generateBlogMetadata } from "@/lib/blog-metadata";
+import { ArticleJsonLd } from "@/components/ArticleJsonLd";
 
 export async function generateMetadata(): Promise<Metadata> {
   return generateBlogMetadata(__dirname);
 }
 
 export default function Layout({ children }: { children: React.ReactNode }) {
-  return children;
+  return (
+    <>
+      <ArticleJsonLd dirPath={__dirname} />
+      {children}
+    </>
+  );
 }

--- a/src/app/blog/when-tokenization-becomes-token/layout.tsx
+++ b/src/app/blog/when-tokenization-becomes-token/layout.tsx
@@ -1,10 +1,16 @@
 import type { Metadata } from "next";
 import { generateBlogMetadata } from "@/lib/blog-metadata";
+import { ArticleJsonLd } from "@/components/ArticleJsonLd";
 
 export async function generateMetadata(): Promise<Metadata> {
   return generateBlogMetadata(__dirname);
 }
 
 export default function Layout({ children }: { children: React.ReactNode }) {
-  return children;
+  return (
+    <>
+      <ArticleJsonLd dirPath={__dirname} />
+      {children}
+    </>
+  );
 }

--- a/src/app/customers/case-study-alibaba/layout.tsx
+++ b/src/app/customers/case-study-alibaba/layout.tsx
@@ -1,10 +1,16 @@
 import type { Metadata } from "next";
 import { generateBlogMetadata } from "@/lib/blog-metadata";
+import { ArticleJsonLd } from "@/components/ArticleJsonLd";
 
 export async function generateMetadata(): Promise<Metadata> {
   return generateBlogMetadata(__dirname);
 }
 
 export default function Layout({ children }: { children: React.ReactNode }) {
-  return children;
+  return (
+    <>
+      <ArticleJsonLd dirPath={__dirname} />
+      {children}
+    </>
+  );
 }

--- a/src/app/customers/case-study-bilt/layout.tsx
+++ b/src/app/customers/case-study-bilt/layout.tsx
@@ -1,10 +1,16 @@
 import type { Metadata } from "next";
 import { generateBlogMetadata } from "@/lib/blog-metadata";
+import { ArticleJsonLd } from "@/components/ArticleJsonLd";
 
 export async function generateMetadata(): Promise<Metadata> {
   return generateBlogMetadata(__dirname);
 }
 
 export default function Layout({ children }: { children: React.ReactNode }) {
-  return children;
+  return (
+    <>
+      <ArticleJsonLd dirPath={__dirname} />
+      {children}
+    </>
+  );
 }

--- a/src/app/customers/case-study-cofactr/layout.tsx
+++ b/src/app/customers/case-study-cofactr/layout.tsx
@@ -1,10 +1,16 @@
 import type { Metadata } from "next";
 import { generateBlogMetadata } from "@/lib/blog-metadata";
+import { ArticleJsonLd } from "@/components/ArticleJsonLd";
 
 export async function generateMetadata(): Promise<Metadata> {
   return generateBlogMetadata(__dirname);
 }
 
 export default function Layout({ children }: { children: React.ReactNode }) {
-  return children;
+  return (
+    <>
+      <ArticleJsonLd dirPath={__dirname} />
+      {children}
+    </>
+  );
 }

--- a/src/app/customers/case-study-insa/layout.tsx
+++ b/src/app/customers/case-study-insa/layout.tsx
@@ -1,10 +1,16 @@
 import type { Metadata } from "next";
 import { generateBlogMetadata } from "@/lib/blog-metadata";
+import { ArticleJsonLd } from "@/components/ArticleJsonLd";
 
 export async function generateMetadata(): Promise<Metadata> {
   return generateBlogMetadata(__dirname);
 }
 
 export default function Layout({ children }: { children: React.ReactNode }) {
-  return children;
+  return (
+    <>
+      <ArticleJsonLd dirPath={__dirname} />
+      {children}
+    </>
+  );
 }

--- a/src/app/customers/case-study-modern-treasury/layout.tsx
+++ b/src/app/customers/case-study-modern-treasury/layout.tsx
@@ -1,10 +1,16 @@
 import type { Metadata } from "next";
 import { generateBlogMetadata } from "@/lib/blog-metadata";
+import { ArticleJsonLd } from "@/components/ArticleJsonLd";
 
 export async function generateMetadata(): Promise<Metadata> {
   return generateBlogMetadata(__dirname);
 }
 
 export default function Layout({ children }: { children: React.ReactNode }) {
-  return children;
+  return (
+    <>
+      <ArticleJsonLd dirPath={__dirname} />
+      {children}
+    </>
+  );
 }

--- a/src/app/customers/case-study-sweetspot/layout.tsx
+++ b/src/app/customers/case-study-sweetspot/layout.tsx
@@ -1,10 +1,16 @@
 import type { Metadata } from "next";
 import { generateBlogMetadata } from "@/lib/blog-metadata";
+import { ArticleJsonLd } from "@/components/ArticleJsonLd";
 
 export async function generateMetadata(): Promise<Metadata> {
   return generateBlogMetadata(__dirname);
 }
 
 export default function Layout({ children }: { children: React.ReactNode }) {
-  return children;
+  return (
+    <>
+      <ArticleJsonLd dirPath={__dirname} />
+      {children}
+    </>
+  );
 }

--- a/src/app/customers/case-study-terrapin-finance/layout.tsx
+++ b/src/app/customers/case-study-terrapin-finance/layout.tsx
@@ -1,10 +1,16 @@
 import type { Metadata } from "next";
 import { generateBlogMetadata } from "@/lib/blog-metadata";
+import { ArticleJsonLd } from "@/components/ArticleJsonLd";
 
 export async function generateMetadata(): Promise<Metadata> {
   return generateBlogMetadata(__dirname);
 }
 
 export default function Layout({ children }: { children: React.ReactNode }) {
-  return children;
+  return (
+    <>
+      <ArticleJsonLd dirPath={__dirname} />
+      {children}
+    </>
+  );
 }

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -7,6 +7,12 @@ import { Inter } from "next/font/google";
 import Script from "next/script";
 import { GoogleTagManager } from "@next/third-parties/google";
 import CookieConsentLoader from "@/components/CookieConsentLoader";
+import { JsonLd } from "@/components/JsonLd";
+import {
+  organizationSchema,
+  softwareApplicationSchema,
+  websiteSchema,
+} from "@/lib/structured-data";
 import { siteConfig } from "./siteConfig";
 
 import "./globals.css";
@@ -69,6 +75,21 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="en" suppressHydrationWarning>
+      <head>
+        <link
+          rel="llms"
+          type="text/markdown"
+          href="/llms.txt"
+          title="ParadeDB llms.txt"
+        />
+        <JsonLd
+          data={[
+            organizationSchema(),
+            websiteSchema(),
+            softwareApplicationSchema(),
+          ]}
+        />
+      </head>
       <body
         className={`${inter.className} min-h-screen overflow-x-hidden antialiased bg-background text-foreground selection:bg-indigo-100 dark:selection:bg-indigo-900 selection:text-indigo-700 dark:selection:text-indigo-300`}
       >

--- a/src/app/learn/postgresql/pgvector-limitations/layout.tsx
+++ b/src/app/learn/postgresql/pgvector-limitations/layout.tsx
@@ -1,10 +1,16 @@
 import type { Metadata } from "next";
 import { generateBlogMetadata } from "@/lib/blog-metadata";
+import { ArticleJsonLd } from "@/components/ArticleJsonLd";
 
 export async function generateMetadata(): Promise<Metadata> {
   return generateBlogMetadata(__dirname);
 }
 
 export default function Layout({ children }: { children: React.ReactNode }) {
-  return children;
+  return (
+    <>
+      <ArticleJsonLd dirPath={__dirname} />
+      {children}
+    </>
+  );
 }

--- a/src/app/learn/postgresql/tuning-pgvector/layout.tsx
+++ b/src/app/learn/postgresql/tuning-pgvector/layout.tsx
@@ -1,10 +1,16 @@
 import type { Metadata } from "next";
 import { generateBlogMetadata } from "@/lib/blog-metadata";
+import { ArticleJsonLd } from "@/components/ArticleJsonLd";
 
 export async function generateMetadata(): Promise<Metadata> {
   return generateBlogMetadata(__dirname);
 }
 
 export default function Layout({ children }: { children: React.ReactNode }) {
-  return children;
+  return (
+    <>
+      <ArticleJsonLd dirPath={__dirname} />
+      {children}
+    </>
+  );
 }

--- a/src/app/learn/postgresql/what-is-pgrx/layout.tsx
+++ b/src/app/learn/postgresql/what-is-pgrx/layout.tsx
@@ -1,10 +1,16 @@
 import type { Metadata } from "next";
 import { generateBlogMetadata } from "@/lib/blog-metadata";
+import { ArticleJsonLd } from "@/components/ArticleJsonLd";
 
 export async function generateMetadata(): Promise<Metadata> {
   return generateBlogMetadata(__dirname);
 }
 
 export default function Layout({ children }: { children: React.ReactNode }) {
-  return children;
+  return (
+    <>
+      <ArticleJsonLd dirPath={__dirname} />
+      {children}
+    </>
+  );
 }

--- a/src/app/learn/postgresql/what-is-pgvector/layout.tsx
+++ b/src/app/learn/postgresql/what-is-pgvector/layout.tsx
@@ -1,10 +1,16 @@
 import type { Metadata } from "next";
 import { generateBlogMetadata } from "@/lib/blog-metadata";
+import { ArticleJsonLd } from "@/components/ArticleJsonLd";
 
 export async function generateMetadata(): Promise<Metadata> {
   return generateBlogMetadata(__dirname);
 }
 
 export default function Layout({ children }: { children: React.ReactNode }) {
-  return children;
+  return (
+    <>
+      <ArticleJsonLd dirPath={__dirname} />
+      {children}
+    </>
+  );
 }

--- a/src/app/learn/search-concepts/block-wand/layout.tsx
+++ b/src/app/learn/search-concepts/block-wand/layout.tsx
@@ -1,10 +1,16 @@
 import type { Metadata } from "next";
 import { generateBlogMetadata } from "@/lib/blog-metadata";
+import { ArticleJsonLd } from "@/components/ArticleJsonLd";
 
 export async function generateMetadata(): Promise<Metadata> {
   return generateBlogMetadata(__dirname);
 }
 
 export default function Layout({ children }: { children: React.ReactNode }) {
-  return children;
+  return (
+    <>
+      <ArticleJsonLd dirPath={__dirname} />
+      {children}
+    </>
+  );
 }

--- a/src/app/learn/search-concepts/bm25/layout.tsx
+++ b/src/app/learn/search-concepts/bm25/layout.tsx
@@ -1,10 +1,16 @@
 import type { Metadata } from "next";
 import { generateBlogMetadata } from "@/lib/blog-metadata";
+import { ArticleJsonLd } from "@/components/ArticleJsonLd";
 
 export async function generateMetadata(): Promise<Metadata> {
   return generateBlogMetadata(__dirname);
 }
 
 export default function Layout({ children }: { children: React.ReactNode }) {
-  return children;
+  return (
+    <>
+      <ArticleJsonLd dirPath={__dirname} />
+      {children}
+    </>
+  );
 }

--- a/src/app/learn/search-concepts/faceting/layout.tsx
+++ b/src/app/learn/search-concepts/faceting/layout.tsx
@@ -1,10 +1,16 @@
 import type { Metadata } from "next";
 import { generateBlogMetadata } from "@/lib/blog-metadata";
+import { ArticleJsonLd } from "@/components/ArticleJsonLd";
 
 export async function generateMetadata(): Promise<Metadata> {
   return generateBlogMetadata(__dirname);
 }
 
 export default function Layout({ children }: { children: React.ReactNode }) {
-  return children;
+  return (
+    <>
+      <ArticleJsonLd dirPath={__dirname} />
+      {children}
+    </>
+  );
 }

--- a/src/app/learn/search-concepts/full-text-search/layout.tsx
+++ b/src/app/learn/search-concepts/full-text-search/layout.tsx
@@ -1,10 +1,16 @@
 import type { Metadata } from "next";
 import { generateBlogMetadata } from "@/lib/blog-metadata";
+import { ArticleJsonLd } from "@/components/ArticleJsonLd";
 
 export async function generateMetadata(): Promise<Metadata> {
   return generateBlogMetadata(__dirname);
 }
 
 export default function Layout({ children }: { children: React.ReactNode }) {
-  return children;
+  return (
+    <>
+      <ArticleJsonLd dirPath={__dirname} />
+      {children}
+    </>
+  );
 }

--- a/src/app/learn/search-concepts/hybrid-search/layout.tsx
+++ b/src/app/learn/search-concepts/hybrid-search/layout.tsx
@@ -1,10 +1,16 @@
 import type { Metadata } from "next";
 import { generateBlogMetadata } from "@/lib/blog-metadata";
+import { ArticleJsonLd } from "@/components/ArticleJsonLd";
 
 export async function generateMetadata(): Promise<Metadata> {
   return generateBlogMetadata(__dirname);
 }
 
 export default function Layout({ children }: { children: React.ReactNode }) {
-  return children;
+  return (
+    <>
+      <ArticleJsonLd dirPath={__dirname} />
+      {children}
+    </>
+  );
 }

--- a/src/app/learn/search-concepts/lexical-vs-semantic/layout.tsx
+++ b/src/app/learn/search-concepts/lexical-vs-semantic/layout.tsx
@@ -1,10 +1,16 @@
 import type { Metadata } from "next";
 import { generateBlogMetadata } from "@/lib/blog-metadata";
+import { ArticleJsonLd } from "@/components/ArticleJsonLd";
 
 export async function generateMetadata(): Promise<Metadata> {
   return generateBlogMetadata(__dirname);
 }
 
 export default function Layout({ children }: { children: React.ReactNode }) {
-  return children;
+  return (
+    <>
+      <ArticleJsonLd dirPath={__dirname} />
+      {children}
+    </>
+  );
 }

--- a/src/app/learn/search-concepts/reciprocal-rank-fusion/layout.tsx
+++ b/src/app/learn/search-concepts/reciprocal-rank-fusion/layout.tsx
@@ -1,10 +1,16 @@
 import type { Metadata } from "next";
 import { generateBlogMetadata } from "@/lib/blog-metadata";
+import { ArticleJsonLd } from "@/components/ArticleJsonLd";
 
 export async function generateMetadata(): Promise<Metadata> {
   return generateBlogMetadata(__dirname);
 }
 
 export default function Layout({ children }: { children: React.ReactNode }) {
-  return children;
+  return (
+    <>
+      <ArticleJsonLd dirPath={__dirname} />
+      {children}
+    </>
+  );
 }

--- a/src/app/learn/search-concepts/retrieval-augmented-generation/layout.tsx
+++ b/src/app/learn/search-concepts/retrieval-augmented-generation/layout.tsx
@@ -1,10 +1,16 @@
 import type { Metadata } from "next";
 import { generateBlogMetadata } from "@/lib/blog-metadata";
+import { ArticleJsonLd } from "@/components/ArticleJsonLd";
 
 export async function generateMetadata(): Promise<Metadata> {
   return generateBlogMetadata(__dirname);
 }
 
 export default function Layout({ children }: { children: React.ReactNode }) {
-  return children;
+  return (
+    <>
+      <ArticleJsonLd dirPath={__dirname} />
+      {children}
+    </>
+  );
 }

--- a/src/app/learn/search-concepts/vector-search/layout.tsx
+++ b/src/app/learn/search-concepts/vector-search/layout.tsx
@@ -1,10 +1,16 @@
 import type { Metadata } from "next";
 import { generateBlogMetadata } from "@/lib/blog-metadata";
+import { ArticleJsonLd } from "@/components/ArticleJsonLd";
 
 export async function generateMetadata(): Promise<Metadata> {
   return generateBlogMetadata(__dirname);
 }
 
 export default function Layout({ children }: { children: React.ReactNode }) {
-  return children;
+  return (
+    <>
+      <ArticleJsonLd dirPath={__dirname} />
+      {children}
+    </>
+  );
 }

--- a/src/app/learn/search-in-postgresql/bm25/layout.tsx
+++ b/src/app/learn/search-in-postgresql/bm25/layout.tsx
@@ -1,10 +1,16 @@
 import type { Metadata } from "next";
 import { generateBlogMetadata } from "@/lib/blog-metadata";
+import { ArticleJsonLd } from "@/components/ArticleJsonLd";
 
 export async function generateMetadata(): Promise<Metadata> {
   return generateBlogMetadata(__dirname);
 }
 
 export default function Layout({ children }: { children: React.ReactNode }) {
-  return children;
+  return (
+    <>
+      <ArticleJsonLd dirPath={__dirname} />
+      {children}
+    </>
+  );
 }

--- a/src/app/learn/search-in-postgresql/full-text-search/layout.tsx
+++ b/src/app/learn/search-in-postgresql/full-text-search/layout.tsx
@@ -1,10 +1,16 @@
 import type { Metadata } from "next";
 import { generateBlogMetadata } from "@/lib/blog-metadata";
+import { ArticleJsonLd } from "@/components/ArticleJsonLd";
 
 export async function generateMetadata(): Promise<Metadata> {
   return generateBlogMetadata(__dirname);
 }
 
 export default function Layout({ children }: { children: React.ReactNode }) {
-  return children;
+  return (
+    <>
+      <ArticleJsonLd dirPath={__dirname} />
+      {children}
+    </>
+  );
 }

--- a/src/app/learn/tantivy/introduction/layout.tsx
+++ b/src/app/learn/tantivy/introduction/layout.tsx
@@ -1,10 +1,16 @@
 import type { Metadata } from "next";
 import { generateBlogMetadata } from "@/lib/blog-metadata";
+import { ArticleJsonLd } from "@/components/ArticleJsonLd";
 
 export async function generateMetadata(): Promise<Metadata> {
   return generateBlogMetadata(__dirname);
 }
 
 export default function Layout({ children }: { children: React.ReactNode }) {
-  return children;
+  return (
+    <>
+      <ArticleJsonLd dirPath={__dirname} />
+      {children}
+    </>
+  );
 }

--- a/src/components/ArticleJsonLd.tsx
+++ b/src/components/ArticleJsonLd.tsx
@@ -1,0 +1,12 @@
+import { JsonLd } from "@/components/JsonLd";
+import { getArticleStructuredData } from "@/lib/structured-data";
+
+/**
+ * Server component that emits Article + BreadcrumbList JSON-LD for a content
+ * page. Pass the post's `__dirname` from its layout.tsx.
+ */
+export function ArticleJsonLd({ dirPath }: { dirPath: string }) {
+  const data = getArticleStructuredData(dirPath);
+  if (!data) return null;
+  return <JsonLd data={data} />;
+}

--- a/src/components/JsonLd.tsx
+++ b/src/components/JsonLd.tsx
@@ -1,0 +1,23 @@
+/**
+ * Renders one or more schema.org objects as JSON-LD <script> tags.
+ *
+ * `<` is escaped to `<` to prevent the JSON payload from breaking out of
+ * the surrounding <script> element.
+ */
+export function JsonLd({ data }: { data: object | object[] }) {
+  const items = Array.isArray(data) ? data : [data];
+
+  return (
+    <>
+      {items.map((item, index) => (
+        <script
+          key={index}
+          type="application/ld+json"
+          dangerouslySetInnerHTML={{
+            __html: JSON.stringify(item).replace(/</g, "\\u003c"),
+          }}
+        />
+      ))}
+    </>
+  );
+}

--- a/src/lib/structured-data.ts
+++ b/src/lib/structured-data.ts
@@ -1,0 +1,176 @@
+import { existsSync, readFileSync } from "fs";
+import { join, sep } from "path";
+import { siteConfig } from "@/app/siteConfig";
+import { github, social } from "@/lib/links";
+
+/**
+ * Stable @id values let separate schema.org nodes reference one another
+ * (e.g. an Article's `publisher` points at the Organization node).
+ */
+const ORG_ID = `${siteConfig.url}/#organization`;
+const WEBSITE_ID = `${siteConfig.url}/#website`;
+
+const ORG_LOGO = `${siteConfig.url}/brand/paradedb-logo-light.svg`;
+
+/** schema.org Organization — the publisher behind every page. */
+export function organizationSchema() {
+  return {
+    "@context": "https://schema.org",
+    "@type": "Organization",
+    "@id": ORG_ID,
+    name: siteConfig.name,
+    legalName: "ParadeDB, Inc.",
+    url: siteConfig.url,
+    logo: {
+      "@type": "ImageObject",
+      url: ORG_LOGO,
+    },
+    description: siteConfig.description,
+    sameAs: [github.REPO, social.TWITTER, social.LINKEDIN],
+  };
+}
+
+/** schema.org WebSite — the marketing site as a whole. */
+export function websiteSchema() {
+  return {
+    "@context": "https://schema.org",
+    "@type": "WebSite",
+    "@id": WEBSITE_ID,
+    name: siteConfig.name,
+    url: siteConfig.url,
+    description: siteConfig.description,
+    publisher: { "@id": ORG_ID },
+  };
+}
+
+/** schema.org SoftwareApplication — ParadeDB the product. */
+export function softwareApplicationSchema() {
+  return {
+    "@context": "https://schema.org",
+    "@type": "SoftwareApplication",
+    name: siteConfig.name,
+    applicationCategory: "DeveloperApplication",
+    applicationSubCategory: "Database",
+    operatingSystem: "Linux, macOS, Docker, Kubernetes",
+    description: siteConfig.description,
+    url: siteConfig.url,
+    downloadUrl: github.REPO,
+    softwareHelp: "https://docs.paradedb.com",
+    license: "https://github.com/paradedb/paradedb/blob/main/LICENSE",
+    author: { "@id": ORG_ID },
+    publisher: { "@id": ORG_ID },
+    offers: {
+      "@type": "Offer",
+      price: "0",
+      priceCurrency: "USD",
+    },
+  };
+}
+
+interface PostMetadata {
+  title: string;
+  description: string;
+  date: string;
+  updated?: string;
+  author: string | string[];
+  categories?: string[];
+  canonical?: string;
+}
+
+const SECTION_NAMES: Record<string, string> = {
+  blog: "Blog",
+  learn: "Learn",
+  customers: "Customers",
+};
+
+/**
+ * Resolve a content directory (passed as `__dirname` from a post layout) into
+ * its public URL and on-disk source path. Mirrors the logic in
+ * `blog-metadata.ts` so structured data stays in sync with page metadata.
+ */
+function resolvePost(dirPath: string) {
+  const blogIndex = dirPath.lastIndexOf(`${sep}blog${sep}`);
+  const learnIndex = dirPath.lastIndexOf(`${sep}learn${sep}`);
+  const customersIndex = dirPath.lastIndexOf(`${sep}customers${sep}`);
+  const maxIndex = Math.max(blogIndex, learnIndex, customersIndex);
+
+  let section: "blog" | "learn" | "customers";
+  let slug: string;
+
+  if (maxIndex === customersIndex && customersIndex >= 0) {
+    section = "customers";
+    slug = dirPath.split(`${sep}customers${sep}`).slice(-1)[0];
+  } else if (maxIndex === learnIndex && learnIndex >= 0) {
+    section = "learn";
+    slug = dirPath.split(`${sep}learn${sep}`).slice(-1)[0];
+  } else {
+    section = "blog";
+    slug = dirPath.split(`${sep}blog${sep}`).slice(-1)[0];
+  }
+
+  const url = `${siteConfig.url}/${section}/${slug}`;
+  const sourceDir = join(process.cwd(), "src", "app", section, slug);
+  return { section, slug, url, sourceDir };
+}
+
+/**
+ * Build Article (or BlogPosting) + BreadcrumbList schema for a content page.
+ * Returns `null` when no metadata.json is present so callers can render nothing.
+ */
+export function getArticleStructuredData(dirPath: string): object[] | null {
+  const { section, url, sourceDir } = resolvePost(dirPath);
+
+  let metadata: PostMetadata;
+  try {
+    metadata = JSON.parse(
+      readFileSync(join(sourceDir, "metadata.json"), "utf8"),
+    );
+  } catch {
+    return null;
+  }
+
+  const canonical = metadata.canonical || url;
+  const authors = Array.isArray(metadata.author)
+    ? metadata.author
+    : [metadata.author];
+
+  const ogImagePath = join(sourceDir, "images/opengraph-image.png");
+  const image = existsSync(ogImagePath)
+    ? `${url}/images/opengraph-image.png`
+    : `${siteConfig.url}/opengraph-image.png`;
+
+  const article = {
+    "@context": "https://schema.org",
+    "@type": section === "blog" ? "BlogPosting" : "Article",
+    headline: metadata.title,
+    description: metadata.description,
+    datePublished: metadata.date,
+    dateModified: metadata.updated || metadata.date,
+    author: authors.map((name) => ({ "@type": "Person", name })),
+    publisher: { "@id": ORG_ID },
+    image,
+    url: canonical,
+    mainEntityOfPage: { "@type": "WebPage", "@id": canonical },
+    isPartOf: { "@id": WEBSITE_ID },
+    ...(metadata.categories?.length
+      ? { keywords: metadata.categories.join(", ") }
+      : {}),
+  };
+
+  const breadcrumb = {
+    "@context": "https://schema.org",
+    "@type": "BreadcrumbList",
+    itemListElement: [
+      { "@type": "ListItem", position: 1, name: "Home", item: siteConfig.url },
+      {
+        "@type": "ListItem",
+        position: 2,
+        name: SECTION_NAMES[section],
+        item: `${siteConfig.url}/${section}`,
+      },
+      { "@type": "ListItem", position: 3, name: metadata.title, item: url },
+    ],
+  };
+
+  return [article, breadcrumb];
+}


### PR DESCRIPTION
# Ticket(s) Closed

None

## What

Add machine-readable structured data and agent-discovery signals to the marketing site, targeting the gaps in our [ora.ai agent-readiness score](https://ora.ai/score/paradedb.com) (Discovery, Identity).

## Why

ora rates `paradedb.com` 54/100, with the weakest categories being agent discoverability and identity. The site previously had **no JSON-LD structured data**, no `security.txt`, and no explicit AI-crawler signals. These are the cheapest, highest-leverage wins: crawlers and answer engines rely on `schema.org` markup to understand who we are and what each page is, and on `/.well-known/security.txt` + agent-aware `robots.txt` as trust/discovery signals.

## How

**`schema.org` JSON-LD (new)**

- `src/components/JsonLd.tsx` — renders one or more schema objects as `<script type="application/ld+json">`, escaping `<` to `<`.
- `src/lib/structured-data.ts` — builders for `Organization` (with `sameAs` → GitHub/X/LinkedIn), `WebSite`, `SoftwareApplication` (license, free `offers`, docs link), and per-post `BlogPosting`/`Article` + `BreadcrumbList`. The post resolver mirrors `blog-metadata.ts` so structured data stays in sync with page metadata.
- `src/components/ArticleJsonLd.tsx` — server component that reads a post's `metadata.json` from its `__dirname`.

**Wiring**

- `src/app/layout.tsx` — emits `Organization` + `WebSite` + `SoftwareApplication` site-wide, plus a `<link rel="llms">` head tag.
- 47 per-post `layout.tsx` files (`/blog`, `/customers`, `/learn`) — render `<ArticleJsonLd dirPath={__dirname} />`. Section index layouts are untouched.

**Discovery / Identity signals**

- `public/.well-known/security.txt` — RFC 9116 (contact `security@paradedb.com`, policy → `SECURITY.md`, expires 2027-05-21).
- `next-sitemap.config.js` — explicit `Allow` policies for reputable agent crawlers (`GPTBot`, `OAI-SearchBot`, `ChatGPT-User`, `ClaudeBot`, `Claude-User`, `PerplexityBot`, `Google-Extended`, `Applebot-Extended`, `CCBot`, etc.) on top of the existing wildcard.
- `next.config.mjs` — `Link: </llms.txt>; rel="llms"` header on all responses.

## Tests

- `pnpm run build` passes (all pages prerender; `next-sitemap` + `llms.txt` generation succeed).
- `pnpm run lint` passes (0 errors).
- Verified built HTML: homepage contains `Organization`/`WebSite`/`SoftwareApplication` JSON-LD; a blog post contains `BlogPosting` + `BreadcrumbList`; `rel="llms"` link tag present.
- Verified regenerated `robots.txt` lists all agent policies and `public/.well-known/security.txt` is served.
