### PR TITLE
feat: Enrich Organization schema and advertise llms-full.txt

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -40,7 +40,8 @@ const nextConfig = {
           {
             key: "Link",
             value:
-              '</llms.txt>; rel="llms"; type="text/markdown"; title="ParadeDB llms.txt"',
+              '</llms.txt>; rel="llms"; type="text/markdown"; title="ParadeDB llms.txt", ' +
+              '</llms-full.txt>; rel="llms-full"; type="text/markdown"; title="ParadeDB llms-full.txt"',
           },
         ],
       },

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -82,6 +82,12 @@ export default function RootLayout({
           href="/llms.txt"
           title="ParadeDB llms.txt"
         />
+        <link
+          rel="llms-full"
+          type="text/markdown"
+          href="/llms-full.txt"
+          title="ParadeDB llms-full.txt"
+        />
         <JsonLd
           data={[
             organizationSchema(),

--- a/src/lib/links.ts
+++ b/src/lib/links.ts
@@ -22,6 +22,7 @@ export const legal = {
 };
 
 export const github = {
+  ORG: "https://github.com/paradedb",
   REPO: "https://github.com/paradedb/paradedb",
   API: "https://api.github.com/repos/paradedb/paradedb",
 };

--- a/src/lib/structured-data.ts
+++ b/src/lib/structured-data.ts
@@ -1,7 +1,12 @@
 import { existsSync, readFileSync } from "fs";
 import { join, sep } from "path";
 import { siteConfig } from "@/app/siteConfig";
-import { github, social } from "@/lib/links";
+import { email, github, social } from "@/lib/links";
+
+/** Strip the `mailto:` prefix from a links.ts email entry. */
+function mailto(value: string) {
+  return value.replace(/^mailto:/, "");
+}
 
 /**
  * Stable @id values let separate schema.org nodes reference one another
@@ -26,7 +31,20 @@ export function organizationSchema() {
       url: ORG_LOGO,
     },
     description: siteConfig.description,
-    sameAs: [github.REPO, social.TWITTER, social.LINKEDIN],
+    email: mailto(email.HELLO),
+    contactPoint: [
+      {
+        "@type": "ContactPoint",
+        contactType: "customer support",
+        email: mailto(email.SUPPORT),
+      },
+      {
+        "@type": "ContactPoint",
+        contactType: "sales",
+        email: mailto(email.SALES),
+      },
+    ],
+    sameAs: [github.ORG, social.TWITTER, social.LINKEDIN],
   };
 }
 


### PR DESCRIPTION
# Ticket(s) Closed

None

## What

Strengthen the Identity and Discovery signals from PR #305 with a richer `Organization` schema and explicit `llms-full.txt` advertisement.

## Why

Follow-up polish on the [ora.ai agent-readiness](https://ora.ai/score/paradedb.com) work. A fuller `Organization` node (contact points, canonical org profile) is a stronger identity signal, and advertising `llms-full.txt` — not just `llms.txt` — helps agents find the full-content file added in PR #306.

## How

**`src/lib/structured-data.ts`** — `organizationSchema()`:

- Add `email` (`hello@paradedb.com`) and a `contactPoint` array (`customer support` → `support@`, `sales` → `sales@`), sourced from `links.ts`.
- Point `sameAs` at the GitHub **org** (`github.com/paradedb`) instead of the repo.

**`src/lib/links.ts`** — add `github.ORG`.

**Discovery** — advertise `llms-full.txt` alongside `llms.txt`:

- `next.config.mjs` — second `Link` rel (`rel="llms-full"`).
- `src/app/layout.tsx` — second `<link rel="llms-full">` head tag.

## Tests

- `pnpm run build` passes.
- `pnpm run lint` (0 errors) and `prettier --check` clean.
- Verified built homepage `Organization` JSON-LD contains `contactPoint`, `customer support`, and `sameAs` → `github.com/paradedb`.
