### PR TITLE
feat: Point article actions at clean .md and add View as Markdown

### DIFF
--- a/src/components/ArticleActions.tsx
+++ b/src/components/ArticleActions.tsx
@@ -55,6 +55,17 @@ export default function ArticleActions({
           <FocusMode className={linkClass} />
         </li>
         <li>
+          <a
+            href={mdPath}
+            target="_blank"
+            rel="noopener noreferrer"
+            className={linkClass}
+          >
+            <RiMarkdownLine size={16} className="shrink-0" />
+            View as Markdown
+          </a>
+        </li>
+        <li>
           <button
             onClick={handleCopyMarkdown}
             className={`${linkClass} w-full`}
@@ -66,17 +77,6 @@ export default function ArticleActions({
             )}
             {copied ? "Copied!" : "Copy Markdown"}
           </button>
-        </li>
-        <li>
-          <a
-            href={mdPath}
-            target="_blank"
-            rel="noopener noreferrer"
-            className={linkClass}
-          >
-            <RiMarkdownLine size={16} className="shrink-0" />
-            View as Markdown
-          </a>
         </li>
         <li>
           <a

--- a/src/components/ArticleActions.tsx
+++ b/src/components/ArticleActions.tsx
@@ -4,12 +4,14 @@ import { useState } from "react";
 import {
   RiFileCopyLine,
   RiCheckLine,
+  RiMarkdownLine,
   RiOpenaiFill,
   RiClaudeFill,
   RiPerplexityFill,
   RiGithubFill,
 } from "@remixicon/react";
 import FocusMode from "@/components/FocusMode";
+import { siteConfig } from "@/app/siteConfig";
 
 interface ArticleActionsProps {
   basePath: string;
@@ -22,15 +24,18 @@ export default function ArticleActions({
 }: ArticleActionsProps) {
   const [copied, setCopied] = useState(false);
 
-  const rawUrl = `https://raw.githubusercontent.com/paradedb/website/main/src/app/${basePath}/${slug}/index.mdx`;
+  // Clean, generated Markdown (see scripts/generate-markdown.js). Same-origin
+  // relative path for fetching; absolute URL for handing to external LLMs.
+  const mdPath = `/${basePath}/${slug}.md`;
+  const mdUrl = `${siteConfig.url}${mdPath}`;
   const editUrl = `https://github.com/paradedb/website/edit/main/src/app/${basePath}/${slug}/index.mdx`;
   const prompt = encodeURIComponent(
-    `Read from ${rawUrl} so I can ask questions about it.`,
+    `Read from ${mdUrl} so I can ask questions about it.`,
   );
 
   const handleCopyMarkdown = async () => {
     try {
-      const res = await fetch(rawUrl);
+      const res = await fetch(mdPath);
       const text = await res.text();
       await navigator.clipboard.writeText(text);
       setCopied(true);
@@ -61,6 +66,17 @@ export default function ArticleActions({
             )}
             {copied ? "Copied!" : "Copy markdown"}
           </button>
+        </li>
+        <li>
+          <a
+            href={mdPath}
+            target="_blank"
+            rel="noopener noreferrer"
+            className={linkClass}
+          >
+            <RiMarkdownLine size={16} className="shrink-0" />
+            View as Markdown
+          </a>
         </li>
         <li>
           <a

--- a/src/components/ArticleActions.tsx
+++ b/src/components/ArticleActions.tsx
@@ -64,7 +64,7 @@ export default function ArticleActions({
             ) : (
               <RiFileCopyLine size={16} className="shrink-0" />
             )}
-            {copied ? "Copied!" : "Copy markdown"}
+            {copied ? "Copied!" : "Copy Markdown"}
           </button>
         </li>
         <li>


### PR DESCRIPTION
# Ticket(s) Closed

None

## What

Point the article action menu (`ArticleActions`) at the clean generated `.md` files instead of the raw GitHub `index.mdx`, and add an explicit **View as Markdown** link.

## Why

The sidebar already had **Copy markdown** and **Open in ChatGPT/Claude/Perplexity** actions, but they fetched `raw.githubusercontent.com/.../index.mdx` — the raw MDX, full of `import` statements and JSX components. Now that PR #306 generates clean `.md` for every page, these actions should serve that instead. This makes copied/LLM-handed content readable and surfaces the `.md` endpoints to users (and agents) — an agent-UX signal ora rewards.

## How

**`src/components/ArticleActions.tsx`**

- Replace `rawUrl` (raw GitHub MDX) with `mdPath` (`/<basePath>/<slug>.md`, same-origin) and `mdUrl` (absolute, via `siteConfig.url`).
- **Copy markdown** now fetches `mdPath`; **Open in ChatGPT/Claude/Perplexity** prompts now reference `mdUrl`.
- Add a **View as Markdown** link (`RiMarkdownLine`) that opens the `.md` directly.
- **Edit on GitHub** still points at the source `index.mdx` (unchanged).

## Tests

- `pnpm run build` passes.
- `pnpm run lint` (0 errors) and `prettier --check` clean.
- Verified `mdPath` resolves to existing generated files for flat (`/blog/<slug>.md`) and nested (`/learn/<section>/<slug>.md`) routes.
