### PR TITLE
feat: Advertise the MCP server for discovery

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -41,7 +41,9 @@ const nextConfig = {
             key: "Link",
             value:
               '</llms.txt>; rel="llms"; type="text/markdown"; title="ParadeDB llms.txt", ' +
-              '</llms-full.txt>; rel="llms-full"; type="text/markdown"; title="ParadeDB llms-full.txt"',
+              '</llms-full.txt>; rel="llms-full"; type="text/markdown"; title="ParadeDB llms-full.txt", ' +
+              '</mcp>; rel="mcp-server"; type="application/json"; title="ParadeDB MCP server", ' +
+              '</.well-known/mcp.json>; rel="mcp-manifest"; type="application/json"; title="ParadeDB MCP manifest"',
           },
         ],
       },

--- a/public/.well-known/mcp.json
+++ b/public/.well-known/mcp.json
@@ -1,0 +1,32 @@
+{
+  "name": "paradedb",
+  "description": "MCP server for ParadeDB's blog posts, customer stories, and learn articles. Search and read ParadeDB's content for full-text search and analytics in Postgres.",
+  "version": "1.0.0",
+  "servers": [
+    {
+      "url": "https://www.paradedb.com/mcp",
+      "transport": "streamable-http",
+      "authentication": "none"
+    }
+  ],
+  "tools": [
+    {
+      "name": "search_content",
+      "description": "Keyword-search ParadeDB's blog, customer stories, and learn articles."
+    },
+    {
+      "name": "get_page",
+      "description": "Fetch the full Markdown of a ParadeDB page by path or slug."
+    },
+    {
+      "name": "list_content",
+      "description": "List all available ParadeDB content with titles and URLs."
+    },
+    {
+      "name": "get_product_info",
+      "description": "Get a structured overview of ParadeDB and key links."
+    }
+  ],
+  "documentation": "https://docs.paradedb.com",
+  "contact": "mailto:hello@paradedb.com"
+}

--- a/scripts/generate-llms-txt.js
+++ b/scripts/generate-llms-txt.js
@@ -18,8 +18,10 @@ const HEADER = `# ParadeDB
 - [RSS Feed](${SITE_URL}/feed.xml)
 - [Content for LLMs (llms.txt)](${SITE_URL}/llms.txt)
 - [Full content for LLMs (llms-full.txt)](${SITE_URL}/llms-full.txt)
+- [MCP Server (streamable HTTP)](${SITE_URL}/mcp)
 
 > Append \`.md\` to any blog, customer, or learn URL (e.g. \`${SITE_URL}/blog/<slug>.md\`) to fetch its Markdown source.
+> An MCP server is available at \`${SITE_URL}/mcp\` (streamable HTTP) with tools to search and read this content.
 `;
 
 // Mirrors SECTION_DISPLAY_NAMES + formatSectionName in src/lib/resources.ts


### PR DESCRIPTION
# Ticket(s) Closed

None

## What

Make the MCP server (added in #309) discoverable by AI agents and agent-readiness scanners, rather than relying on them to guess the `/mcp` path.

## Why

A working MCP endpoint only helps if agents can find it. ora grades MCP on discoverability/best-practices, and the emerging conventions ([SEP-1649 server cards](https://github.com/modelcontextprotocol/modelcontextprotocol/issues/1649), [SEP-1960 `.well-known/mcp`](https://github.com/modelcontextprotocol/modelcontextprotocol/issues/1960)) advertise HTTP MCP servers via a `.well-known` manifest. This adds the low-risk, high-signal discovery hooks.

## How

**`public/.well-known/mcp.json` (new)** — MCP "server card": name, description, the `/mcp` endpoint (`streamable-http`, `authentication: none`), the four tools, and docs/contact links. Served as `application/json`.

**`scripts/generate-llms-txt.js`** — `llms.txt` now lists the MCP server under Website and notes it in prose, so LLMs that read `llms.txt` learn the server exists.

**`next.config.mjs`** — the existing `Link` header now also advertises `</mcp>; rel="mcp-server"` and `</.well-known/mcp.json>; rel="mcp-manifest"`.

## Tests

- `pnpm run build` passes; `prettier --check` clean; `mcp.json` is valid JSON.
- Verified on the local production server:
  - `GET /.well-known/mcp.json` → `200`, `application/json`.
  - Homepage `Link` header includes `rel="llms"`, `rel="llms-full"`, `rel="mcp-server"`, `rel="mcp-manifest"`.
  - `llms.txt` lists the MCP server.
  - `POST /mcp` `initialize` still returns `serverInfo: paradedb` (no regression).

## Notes

The MCP discovery SEPs are active proposals, not finalized; `/.well-known/mcp.json` is the most widely-probed path today. Schema can be adjusted as the spec settles.
