### PR TITLE
fix: Remove invalid site-wide SoftwareApplication structured data

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -8,11 +8,7 @@ import Script from "next/script";
 import { GoogleTagManager } from "@next/third-parties/google";
 import CookieConsentLoader from "@/components/CookieConsentLoader";
 import { JsonLd } from "@/components/JsonLd";
-import {
-  organizationSchema,
-  softwareApplicationSchema,
-  websiteSchema,
-} from "@/lib/structured-data";
+import { organizationSchema, websiteSchema } from "@/lib/structured-data";
 import { siteConfig } from "./siteConfig";
 
 import "./globals.css";
@@ -88,13 +84,7 @@ export default function RootLayout({
           href="/llms-full.txt"
           title="ParadeDB llms-full.txt"
         />
-        <JsonLd
-          data={[
-            organizationSchema(),
-            websiteSchema(),
-            softwareApplicationSchema(),
-          ]}
-        />
+        <JsonLd data={[organizationSchema(), websiteSchema()]} />
       </head>
       <body
         className={`${inter.className} min-h-screen overflow-x-hidden antialiased bg-background text-foreground selection:bg-indigo-100 dark:selection:bg-indigo-900 selection:text-indigo-700 dark:selection:text-indigo-300`}

--- a/src/lib/structured-data.ts
+++ b/src/lib/structured-data.ts
@@ -61,29 +61,25 @@ export function websiteSchema() {
   };
 }
 
-/** schema.org SoftwareApplication — ParadeDB the product. */
-export function softwareApplicationSchema() {
-  return {
-    "@context": "https://schema.org",
-    "@type": "SoftwareApplication",
-    name: siteConfig.name,
-    applicationCategory: "DeveloperApplication",
-    applicationSubCategory: "Database",
-    operatingSystem: "Linux, macOS, Docker, Kubernetes",
-    description: siteConfig.description,
-    url: siteConfig.url,
-    downloadUrl: github.REPO,
-    softwareHelp: "https://docs.paradedb.com",
-    license: "https://github.com/paradedb/paradedb/blob/main/LICENSE",
-    author: { "@id": ORG_ID },
-    publisher: { "@id": ORG_ID },
-    offers: {
-      "@type": "Offer",
-      price: "0",
-      priceCurrency: "USD",
-    },
-  };
-}
+/**
+ * A `SoftwareApplication` schema previously lived here and was emitted on every
+ * page via the root layout. It was removed because Google requires the type to
+ * carry `name`, `offers.price`, AND one of `aggregateRating` or `review`
+ * (https://developers.google.com/search/docs/appearance/structured-data/software-app).
+ * We had no genuine rating/review data, so it was invalid on every page and
+ * SEMrush flagged it across the whole site.
+ *
+ * To bring it back:
+ *   1. Obtain REAL aggregate ratings or a real review — never fabricate them, as
+ *      invented ratings violate Google's guidelines and risk a manual action.
+ *   2. Add a `softwareApplicationSchema()` builder returning at minimum:
+ *        name, offers: { "@type": "Offer", price: "0", priceCurrency: "USD" },
+ *        and aggregateRating: { "@type": "AggregateRating", ratingValue, ratingCount }
+ *        (or a `review`). author/publisher can reference ORG_ID as before.
+ *   3. Emit it ONLY on the product/homepage — not site-wide — since the schema
+ *      makes no semantic sense on blog posts, which is what caused 55 errors.
+ *   4. Validate with the Rich Results Test before shipping.
+ */
 
 interface PostMetadata {
   title: string;


### PR DESCRIPTION
# Ticket(s) Closed

None

## What

Removes the `SoftwareApplication` JSON-LD schema that was emitted on every page via the root layout, and documents what it would take to reintroduce it correctly.

## Why

SEMrush's Site Audit flagged 55 pages with invalid structured data — all the same `SoftwareApplication` item with 1 affected field. Google's [Software App spec](https://developers.google.com/search/docs/appearance/structured-data/software-app) requires the type to carry `name`, `offers.price`, **and** one of `aggregateRating` or `review`. Our schema had `name` and `offers` but no rating or review, so it was invalid everywhere the global layout rendered it (homepage, `/blog`, and every blog post).

We have no genuine rating/review data, and fabricating it would violate Google's guidelines and risk a manual action — so the schema can never validate as-is. Removing it clears all 55 errors. The valid schemas (`Organization`, `WebSite` site-wide; `Article`/`BlogPosting` + `BreadcrumbList` on content pages) are untouched.

## How

**`src/app/layout.tsx`**
- Removed `softwareApplicationSchema` from the import.
- `<JsonLd>` data array: `[organizationSchema(), websiteSchema(), softwareApplicationSchema()]` → `[organizationSchema(), websiteSchema()]`.

**`src/lib/structured-data.ts`**
- Deleted the `softwareApplicationSchema()` builder.
- Added a comment in its place explaining the Google requirements and the steps to add it back: obtain real ratings/reviews, scope it to the homepage only (not site-wide), and validate with the Rich Results Test.

## Tests

- `prettier --check` passes on both changed files.
- Verified no dangling references to `softwareApplicationSchema`; shared `github`/`email`/`social` imports remain in use by the other schemas.
- Errors will clear on the next deploy + SEMrush re-crawl; confirmable sooner via Google's Rich Results Test on a few URLs.