### PR TITLE
ci: rotate Slack invite link and add a monitor for it

### DIFF
--- a/.github/scripts/check-slack-invite.mjs
+++ b/.github/scripts/check-slack-invite.mjs
@@ -41,12 +41,15 @@ const DEAD_PHRASES = [
   "ask for a new link",
 ];
 
-async function classify(browser, url, screenshotPath) {
+async function classify(browser, label, url, screenshotPath) {
+  const t0 = Date.now();
+  console.log(`[${label}] loading ${url} ...`);
   const page = await browser.newPage();
   try {
     // domcontentloaded + settle is more reliable than networkidle here: Slack
     // holds long-lived connections, so networkidle frequently times out.
     await page.goto(url, { waitUntil: "domcontentloaded", timeout: 45000 });
+    console.log(`[${label}] loaded, settling for render ...`);
     await page.waitForTimeout(5000);
     if (screenshotPath) {
       await page.screenshot({ path: screenshotPath, fullPage: true });
@@ -55,8 +58,13 @@ async function classify(browser, url, screenshotPath) {
       await page.evaluate(() => document.body.innerText || "")
     ).toLowerCase();
     const matched = DEAD_PHRASES.find((p) => text.includes(p)) || null;
-    return { dead: Boolean(matched), matched, error: null };
+    const dead = Boolean(matched);
+    console.log(
+      `[${label}] done in ${Date.now() - t0}ms — ${dead ? `DEAD (matched "${matched}")` : "alive"}`,
+    );
+    return { dead, matched, error: null };
   } catch (err) {
+    console.log(`[${label}] errored after ${Date.now() - t0}ms: ${err.message}`);
     return { dead: null, matched: null, error: err.message };
   } finally {
     await page.close();
@@ -74,8 +82,8 @@ let status; // healthy | dead | detector_broken | inconclusive
 let reason;
 
 try {
-  const canary = await classify(browser, DEAD_CANARY, "canary.png");
-  const live = await classify(browser, LIVE_URL, "live.png");
+  const canary = await classify(browser, "canary", DEAD_CANARY, "canary.png");
+  const live = await classify(browser, "live", LIVE_URL, "live.png");
 
   console.log("Canary (known-dead) result:", JSON.stringify(canary));
   console.log("Live  (paradedb.com/slack) result:", JSON.stringify(live));

--- a/.github/scripts/check-slack-invite.mjs
+++ b/.github/scripts/check-slack-invite.mjs
@@ -13,7 +13,7 @@
 // a new invite in the Slack admin and swap the destination in next.config.mjs.
 
 import { chromium } from "playwright";
-import { appendFileSync, writeFileSync } from "node:fs";
+import { appendFileSync } from "node:fs";
 
 const LIVE_URL = "https://paradedb.com/slack";
 
@@ -114,7 +114,7 @@ try {
 }
 
 setOutput("status", status);
-writeFileSync("monitor-reason.txt", reason);
+setOutput("reason", reason);
 
 console.log(`\nSTATUS: ${status}\n${reason}`);
 

--- a/.github/scripts/check-slack-invite.mjs
+++ b/.github/scripts/check-slack-invite.mjs
@@ -1,0 +1,118 @@
+// .github/scripts/check-slack-invite.mjs
+//
+// Health-check the public Slack invite redirect (https://paradedb.com/slack).
+//
+// Why a headless browser and not curl: Slack shared-invite links render their
+// "valid" vs "no longer active" state CLIENT-SIDE in JavaScript. A dead link and
+// a live link return a byte-identical HTML app-shell with a 200 status, so curl /
+// uptime pings cannot tell them apart. We must load the page and read the DOM
+// after the SPA has rendered.
+//
+// Slack invite links auto-deactivate after ~400 joins regardless of the
+// "never expire" setting, so this WILL fire periodically. When it does, generate
+// a new invite in the Slack admin and swap the destination in next.config.mjs.
+
+import { chromium } from "playwright";
+import { appendFileSync, writeFileSync } from "node:fs";
+
+const LIVE_URL = "https://paradedb.com/slack";
+
+// A known-DEAD invite, kept as a calibration canary. Every run we assert the
+// detector still flags this as dead. If it ever reads "alive", Slack changed
+// their page wording and our detection is silently broken — which is its own
+// alert-worthy failure (otherwise we'd get false "all healthy" forever).
+const DEAD_CANARY =
+  "https://join.slack.com/t/paradedbcommunity/shared_invite/zt-32abtyjg4-yoYoi~RPh9MSW8tDbl0BQw";
+
+// Phrases Slack shows on an expired/invalid shared invite. Lowercased substring
+// match against the rendered page text. Broad on purpose — a false "dead" just
+// triggers a manual look, whereas a missed death blocks new users silently.
+const DEAD_PHRASES = [
+  "no longer active",
+  "isn't active",
+  "is not active",
+  "no longer valid",
+  "invite is invalid",
+  "link is invalid",
+  "this link has expired",
+  "invite has expired",
+  "has expired",
+  "reactivate",
+  "ask for a new link",
+];
+
+async function classify(browser, url, screenshotPath) {
+  const page = await browser.newPage();
+  try {
+    // domcontentloaded + settle is more reliable than networkidle here: Slack
+    // holds long-lived connections, so networkidle frequently times out.
+    await page.goto(url, { waitUntil: "domcontentloaded", timeout: 45000 });
+    await page.waitForTimeout(5000);
+    if (screenshotPath) {
+      await page.screenshot({ path: screenshotPath, fullPage: true });
+    }
+    const text = (
+      await page.evaluate(() => document.body.innerText || "")
+    ).toLowerCase();
+    const matched = DEAD_PHRASES.find((p) => text.includes(p)) || null;
+    return { dead: Boolean(matched), matched, error: null };
+  } catch (err) {
+    return { dead: null, matched: null, error: err.message };
+  } finally {
+    await page.close();
+  }
+}
+
+function setOutput(key, value) {
+  if (process.env.GITHUB_OUTPUT) {
+    appendFileSync(process.env.GITHUB_OUTPUT, `${key}=${value}\n`);
+  }
+}
+
+const browser = await chromium.launch();
+let status; // healthy | dead | detector_broken | inconclusive
+let reason;
+
+try {
+  const canary = await classify(browser, DEAD_CANARY, "canary.png");
+  const live = await classify(browser, LIVE_URL, "live.png");
+
+  console.log("Canary (known-dead) result:", JSON.stringify(canary));
+  console.log("Live  (paradedb.com/slack) result:", JSON.stringify(live));
+
+  if (canary.dead !== true) {
+    // The detector can no longer recognize a link it MUST recognize as dead.
+    status = "detector_broken";
+    reason =
+      "The known-dead canary link was NOT detected as dead. Slack likely changed " +
+      "their expired-invite page wording — update DEAD_PHRASES in " +
+      ".github/scripts/check-slack-invite.mjs. Until fixed, this monitor cannot " +
+      "be trusted to catch a real outage.";
+  } else if (live.dead === true) {
+    status = "dead";
+    reason =
+      `The live Slack invite at ${LIVE_URL} is no longer active ` +
+      `(matched: "${live.matched}"). Generate a new invite in the Slack admin and ` +
+      "update the `/slack` destination in next.config.mjs.";
+  } else if (live.dead === null) {
+    status = "inconclusive";
+    reason = `Could not load ${LIVE_URL}: ${live.error}. Will retry next run.`;
+  } else {
+    status = "healthy";
+    reason = "The Slack invite redirect resolves to an active invite.";
+  }
+} finally {
+  await browser.close();
+}
+
+setOutput("status", status);
+writeFileSync("monitor-reason.txt", reason);
+
+console.log(`\nSTATUS: ${status}\n${reason}`);
+
+// Fail the job for actionable states (dead invite, broken detector) so the run
+// goes red and surfaces in the Actions UI / email. "inconclusive" (transient
+// network) does not fail — it just logs and retries next run.
+if (status === "dead" || status === "detector_broken") {
+  process.exitCode = 1;
+}

--- a/.github/workflows/check-slack-invite.yml
+++ b/.github/workflows/check-slack-invite.yml
@@ -28,10 +28,17 @@ permissions:
   contents: read
   issues: write
 
+env:
+  # Pinned so the browser cache key below stays stable across runs.
+  PLAYWRIGHT_VERSION: "1.49.1"
+
 jobs:
   check-slack-invite:
     name: Check Slack Invite
     runs-on: ubuntu-latest
+    # A hung page-load or browser download should fail loudly, not sit there
+    # looking frozen for the full 6h default.
+    timeout-minutes: 20
 
     steps:
       - name: Checkout Git Repository
@@ -42,20 +49,34 @@ jobs:
         with:
           node-version: 24
 
+      # Cache the ~160MB Chromium download so only the first run (cold cache)
+      # pays for it — scheduled daily runs restore it in seconds.
+      - name: Cache Playwright browser
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/ms-playwright
+          key: ms-playwright-${{ runner.os }}-${{ env.PLAYWRIGHT_VERSION }}
+
+      # Separate, visible step so progress is obvious. Installing Playwright in an
+      # isolated temp dir keeps us off the repo's package.json/lockfile (pnpm
+      # project — a stray root `npm install` would clobber it).
+      - name: Install Playwright + Chromium
+        run: |
+          mkdir -p "$RUNNER_TEMP/pw"
+          cd "$RUNNER_TEMP/pw"
+          echo "::group::npm install playwright@$PLAYWRIGHT_VERSION"
+          npm init -y >/dev/null 2>&1
+          npm install "playwright@$PLAYWRIGHT_VERSION" >/dev/null
+          echo "::endgroup::"
+          echo "::group::playwright install --with-deps chromium (downloads ~160MB on a cache miss)"
+          npx playwright install --with-deps chromium
+          echo "::endgroup::"
+
       - name: Probe Slack invite
         id: probe
         run: |
-          # Install Playwright in an isolated temp dir so we never touch the
-          # repo's package.json / lockfile (this project uses pnpm; a stray
-          # `npm install` at the root would clobber it). The script and its
-          # output artifacts live in $work; copy the outputs back to the
-          # workspace so the upload + issue steps can find them.
-          work="$(mktemp -d)"
-          cp .github/scripts/check-slack-invite.mjs "$work/probe.mjs"
-          cd "$work"
-          npm init -y >/dev/null 2>&1
-          npm install playwright@1.49.1 >/dev/null
-          npx playwright install --with-deps chromium
+          cp .github/scripts/check-slack-invite.mjs "$RUNNER_TEMP/pw/probe.mjs"
+          cd "$RUNNER_TEMP/pw"
           # Don't let set -e abort on a failing probe — we still need to copy the
           # screenshots/reason back so the artifact + issue steps can use them.
           set +e

--- a/.github/workflows/check-slack-invite.yml
+++ b/.github/workflows/check-slack-invite.yml
@@ -1,0 +1,130 @@
+# workflows/check-slack-invite.yml
+#
+# Check Slack Invite
+# The public Slack invite link (https://paradedb.com/slack) is served by a 302
+# redirect in next.config.mjs. Slack shared-invite links auto-deactivate after
+# ~400 joins regardless of the "never expire" setting, and they fail silently:
+# an expired link still returns 200 with a JS app-shell identical to a live one,
+# so curl/uptime checks can't catch it. This job renders the page in a headless
+# browser, reads the post-JS DOM, and alerts (red run + GitHub issue) when the
+# invite is dead. It also re-checks a known-dead canary link each run to confirm
+# the detector itself still works. When it fires: generate a fresh invite in the
+# Slack admin and swap the `/slack` destination in next.config.mjs.
+
+name: Check Slack Invite
+
+on:
+  schedule:
+    # Daily at 13:00 UTC. So a dead link is caught within ~24h, not weeks later.
+    - cron: "0 13 * * *"
+  workflow_dispatch:
+
+concurrency:
+  group: check-slack-invite
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  check-slack-invite:
+    name: Check Slack Invite
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout Git Repository
+        uses: actions/checkout@v6
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Probe Slack invite
+        id: probe
+        run: |
+          # Install Playwright in an isolated temp dir so we never touch the
+          # repo's package.json / lockfile (this project uses pnpm; a stray
+          # `npm install` at the root would clobber it). The script and its
+          # output artifacts live in $work; copy the outputs back to the
+          # workspace so the upload + issue steps can find them.
+          work="$(mktemp -d)"
+          cp .github/scripts/check-slack-invite.mjs "$work/probe.mjs"
+          cd "$work"
+          npm init -y >/dev/null 2>&1
+          npm install playwright@1.49.1 >/dev/null
+          npx playwright install --with-deps chromium
+          # Don't let set -e abort on a failing probe — we still need to copy the
+          # screenshots/reason back so the artifact + issue steps can use them.
+          set +e
+          node probe.mjs
+          status=$?
+          set -e
+          cp -f live.png canary.png monitor-reason.txt "$GITHUB_WORKSPACE/" 2>/dev/null || true
+          exit $status
+
+      - name: Upload rendered screenshots
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: slack-invite-screenshots
+          path: |
+            live.png
+            canary.png
+          if-no-files-found: ignore
+          retention-days: 14
+
+      - name: Open or update alert issue
+        # Fire on a dead invite OR a broken detector. Skip the transient
+        # "inconclusive" (network) case so we don't open noise on a blip.
+        if: always() && (steps.probe.outputs.status == 'dead' || steps.probe.outputs.status == 'detector_broken')
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require('fs');
+            const status = '${{ steps.probe.outputs.status }}';
+            const reason = fs.readFileSync('monitor-reason.txt', 'utf8').trim();
+            const marker = '<!-- slack-invite-monitor -->';
+            const title = status === 'dead'
+              ? '🔴 Slack invite link is no longer active'
+              : '⚠️ Slack invite monitor needs attention';
+            const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
+            const body = [
+              marker,
+              `**Status:** \`${status}\``,
+              '',
+              reason,
+              '',
+              status === 'dead'
+                ? '**Fix:** generate a new invite in the Slack admin, then update the `/slack` `destination` in `next.config.mjs`.'
+                : '**Fix:** update `DEAD_PHRASES` in `.github/scripts/check-slack-invite.mjs` to match Slack’s current expired-invite wording.',
+              '',
+              `[View the workflow run](${runUrl}) · screenshots are attached as run artifacts.`,
+            ].join('\n');
+
+            // De-dupe: reuse the open issue this monitor created (matched by the
+            // hidden marker) instead of opening a new one every day.
+            const existing = await github.paginate(github.rest.issues.listForRepo, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              state: 'open',
+              per_page: 100,
+            });
+            const open = existing.find((i) => (i.body || '').includes(marker));
+
+            if (open) {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: open.number,
+                body: `Still failing as of this run.\n\n${body}`,
+              });
+            } else {
+              await github.rest.issues.create({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                title,
+                body,
+              });
+            }

--- a/.github/workflows/check-slack-invite.yml
+++ b/.github/workflows/check-slack-invite.yml
@@ -14,10 +14,6 @@ on:
     # this lands at 2 PM during PDT.
     - cron: "0 21 * * 1-5"
   workflow_dispatch:
-  # TEMPORARY: test end-to-end on this branch before merging. REMOVE before merge.
-  push:
-    branches:
-      - slack-invite-rotate-and-monitor
 
 concurrency:
   group: check-slack-invite-${{ github.head_ref || github.ref }}

--- a/.github/workflows/check-slack-invite.yml
+++ b/.github/workflows/check-slack-invite.yml
@@ -13,33 +13,27 @@ on:
     # Daily at 13:00 UTC. So a dead link is caught within ~24h, not weeks later.
     - cron: "0 13 * * *"
   workflow_dispatch:
-  # TEMPORARY: lets us test the monitor on this branch before merging.
-  # REMOVE this push trigger before merging — the monitor should only run on a
-  # schedule / manual dispatch, not on every push.
-  push:
-    branches:
-      - slack-invite-rotate-and-monitor
 
 concurrency:
-  group: check-slack-invite
+  group: check-slack-invite-${{ github.head_ref || github.ref }}
   cancel-in-progress: true
 
 permissions:
   contents: read
-  issues: write
 
 jobs:
   check-slack-invite:
     name: Check Slack Invite
     runs-on: ubuntu-latest
-    # Run inside the official Playwright image: Chromium + all system deps are
-    # baked in, so there is NO ~160MB browser download at runtime (that download
-    # from Slack's slow CDN was taking 8-10+ min and looked frozen). Keep the
-    # `playwright@` install below pinned to the SAME version as this image tag.
+    # Chromium + deps are baked in, so there's no slow browser download at
+    # runtime. Keep the `playwright@` install below on the same version tag.
     container:
       image: mcr.microsoft.com/playwright:v1.49.1-jammy
     # A hung page-load should fail loudly, not sit there for the 6h default.
     timeout-minutes: 10
+    outputs:
+      status: ${{ steps.probe.outputs.status }}
+      reason: ${{ steps.probe.outputs.reason }}
 
     steps:
       - name: Checkout Git Repository
@@ -62,7 +56,7 @@ jobs:
           node probe.mjs
           status=$?
           set -e
-          cp -f live.png canary.png monitor-reason.txt "$GITHUB_WORKSPACE/" 2>/dev/null || true
+          cp -f live.png canary.png "$GITHUB_WORKSPACE/" 2>/dev/null || true
           exit $status
 
       - name: Upload rendered screenshots
@@ -76,56 +70,43 @@ jobs:
           if-no-files-found: ignore
           retention-days: 7
 
-      - name: Open or update alert issue
-        # Fire on a dead invite OR a broken detector. Skip the transient
-        # "inconclusive" (network) case so we don't open noise on a blip.
-        if: always() && (steps.probe.outputs.status == 'dead' || steps.probe.outputs.status == 'detector_broken')
-        uses: actions/github-script@v7
-        with:
-          script: |
-            const fs = require('fs');
-            const status = '${{ steps.probe.outputs.status }}';
-            const reason = fs.readFileSync('monitor-reason.txt', 'utf8').trim();
-            const marker = '<!-- slack-invite-monitor -->';
-            const title = status === 'dead'
-              ? '🔴 Slack invite link is no longer active'
-              : '⚠️ Slack invite monitor needs attention';
-            const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
-            const body = [
-              marker,
-              `**Status:** \`${status}\``,
-              '',
-              reason,
-              '',
-              status === 'dead'
-                ? '**Fix:** generate a new invite in the Slack admin, then update the `/slack` `destination` in `next.config.mjs`.'
-                : '**Fix:** update `DEAD_PHRASES` in `.github/scripts/check-slack-invite.mjs` to match Slack’s current expired-invite wording.',
-              '',
-              `[View the workflow run](${runUrl}) · screenshots are attached as run artifacts.`,
-            ].join('\n');
-
-            // De-dupe: reuse the open issue this monitor created (matched by the
-            // hidden marker) instead of opening a new one every day.
-            const existing = await github.paginate(github.rest.issues.listForRepo, {
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              state: 'open',
-              per_page: 100,
-            });
-            const open = existing.find((i) => (i.body || '').includes(marker));
-
-            if (open) {
-              await github.rest.issues.createComment({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                issue_number: open.number,
-                body: `Still failing as of this run.\n\n${body}`,
-              });
-            } else {
-              await github.rest.issues.create({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                title,
-                body,
-              });
-            }
+  # Ping Slack when the probe job fails (dead invite or broken detector). The
+  # "inconclusive" network case exits 0, so the probe job stays green and this
+  # won't fire. Mirrors the notify-slack pattern in terraform-paradedb-byoc.
+  notify-slack:
+    name: Notify Slack on Failure
+    needs: [check-slack-invite]
+    if: always() && needs.check-slack-invite.result == 'failure'
+    runs-on: ubuntu-latest
+    env:
+      SLACK_WEBHOOK_URL: ${{ secrets.SLACK_GITHUB_CHANNEL_WEBHOOK_URL }}
+      # Via env (not inline ${{ }}) so quotes in the reason can't break the shell.
+      MONITOR_STATUS: ${{ needs.check-slack-invite.outputs.status }}
+      MONITOR_REASON: ${{ needs.check-slack-invite.outputs.reason }}
+    steps:
+      - name: Send Slack notification
+        run: |
+          if [ -z "$SLACK_WEBHOOK_URL" ]; then
+            echo "SLACK_GITHUB_CHANNEL_WEBHOOK_URL not set — skipping Slack ping."
+            exit 0
+          fi
+          run_url="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+          # jq builds the payload so embedded quotes in the reason are escaped.
+          payload="$(jq -n \
+            --arg status "$MONITOR_STATUS" \
+            --arg reason "$MONITOR_REASON" \
+            --arg repo "${{ github.repository }}" \
+            --arg url "$run_url" \
+            '{
+              text: "🚨 ParadeDB Community Slack invite needs attention - <!here>",
+              attachments: [{
+                color: "danger",
+                fields: [
+                  {title: "Status", value: $status, short: true},
+                  {title: "Repository", value: $repo, short: true},
+                  {title: "Details", value: $reason, short: false},
+                  {title: "View Logs", value: ("<" + $url + "|Click here>"), short: false}
+                ]
+              }]
+            }')"
+          curl -fsS -X POST -H 'Content-type: application/json' --data "$payload" "$SLACK_WEBHOOK_URL"

--- a/.github/workflows/check-slack-invite.yml
+++ b/.github/workflows/check-slack-invite.yml
@@ -14,6 +14,10 @@ on:
     # this lands at 2 PM during PDT.
     - cron: "0 21 * * 1-5"
   workflow_dispatch:
+  # TEMPORARY: test end-to-end on this branch before merging. REMOVE before merge.
+  push:
+    branches:
+      - slack-invite-rotate-and-monitor
 
 concurrency:
   group: check-slack-invite-${{ github.head_ref || github.ref }}
@@ -59,7 +63,7 @@ jobs:
 
       - name: Upload rendered screenshots
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: slack-invite-screenshots
           path: |

--- a/.github/workflows/check-slack-invite.yml
+++ b/.github/workflows/check-slack-invite.yml
@@ -28,55 +28,34 @@ permissions:
   contents: read
   issues: write
 
-env:
-  # Pinned so the browser cache key below stays stable across runs.
-  PLAYWRIGHT_VERSION: "1.49.1"
-
 jobs:
   check-slack-invite:
     name: Check Slack Invite
     runs-on: ubuntu-latest
-    # A hung page-load or browser download should fail loudly, not sit there
-    # looking frozen for the full 6h default.
-    timeout-minutes: 20
+    # Run inside the official Playwright image: Chromium + all system deps are
+    # baked in, so there is NO ~160MB browser download at runtime (that download
+    # from Slack's slow CDN was taking 8-10+ min and looked frozen). Keep the
+    # `playwright@` install below pinned to the SAME version as this image tag.
+    container:
+      image: mcr.microsoft.com/playwright:v1.49.1-jammy
+    # A hung page-load should fail loudly, not sit there for the 6h default.
+    timeout-minutes: 10
 
     steps:
       - name: Checkout Git Repository
         uses: actions/checkout@v6
 
-      - name: Setup Node
-        uses: actions/setup-node@v4
-        with:
-          node-version: 24
-
-      # Cache the ~160MB Chromium download so only the first run (cold cache)
-      # pays for it — scheduled daily runs restore it in seconds.
-      - name: Cache Playwright browser
-        uses: actions/cache@v4
-        with:
-          path: ~/.cache/ms-playwright
-          key: ms-playwright-${{ runner.os }}-${{ env.PLAYWRIGHT_VERSION }}
-
-      # Separate, visible step so progress is obvious. Installing Playwright in an
-      # isolated temp dir keeps us off the repo's package.json/lockfile (pnpm
-      # project — a stray root `npm install` would clobber it).
-      - name: Install Playwright + Chromium
-        run: |
-          mkdir -p "$RUNNER_TEMP/pw"
-          cd "$RUNNER_TEMP/pw"
-          echo "::group::npm install playwright@$PLAYWRIGHT_VERSION"
-          npm init -y >/dev/null 2>&1
-          npm install "playwright@$PLAYWRIGHT_VERSION" >/dev/null
-          echo "::endgroup::"
-          echo "::group::playwright install --with-deps chromium (downloads ~160MB on a cache miss)"
-          npx playwright install --with-deps chromium
-          echo "::endgroup::"
-
       - name: Probe Slack invite
         id: probe
         run: |
+          # Install only the Playwright JS package (seconds — no browser bytes;
+          # the browser is already in the image at $PLAYWRIGHT_BROWSERS_PATH).
+          # Isolated temp dir keeps us off the repo's pnpm package.json/lockfile.
+          mkdir -p "$RUNNER_TEMP/pw"
           cp .github/scripts/check-slack-invite.mjs "$RUNNER_TEMP/pw/probe.mjs"
           cd "$RUNNER_TEMP/pw"
+          npm init -y >/dev/null 2>&1
+          PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1 npm install playwright@1.49.1 >/dev/null
           # Don't let set -e abort on a failing probe — we still need to copy the
           # screenshots/reason back so the artifact + issue steps can use them.
           set +e

--- a/.github/workflows/check-slack-invite.yml
+++ b/.github/workflows/check-slack-invite.yml
@@ -1,15 +1,10 @@
 # workflows/check-slack-invite.yml
 #
 # Check Slack Invite
-# The public Slack invite link (https://paradedb.com/slack) is served by a 302
-# redirect in next.config.mjs. Slack shared-invite links auto-deactivate after
-# ~400 joins regardless of the "never expire" setting, and they fail silently:
-# an expired link still returns 200 with a JS app-shell identical to a live one,
-# so curl/uptime checks can't catch it. This job renders the page in a headless
-# browser, reads the post-JS DOM, and alerts (red run + GitHub issue) when the
-# invite is dead. It also re-checks a known-dead canary link each run to confirm
-# the detector itself still works. When it fires: generate a fresh invite in the
-# Slack admin and swap the `/slack` destination in next.config.mjs.
+# Alerts when the public Slack invite (https://paradedb.com/slack) dies. Slack
+# links auto-deactivate after ~400 joins and fail silently (an expired link
+# still 200s with a live-looking app-shell), so this renders the page in a
+# headless browser to detect it. See check-slack-invite.mjs for details.
 
 name: Check Slack Invite
 
@@ -39,7 +34,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 24
 
       - name: Probe Slack invite
         id: probe
@@ -73,7 +68,7 @@ jobs:
             live.png
             canary.png
           if-no-files-found: ignore
-          retention-days: 14
+          retention-days: 7
 
       - name: Open or update alert issue
         # Fire on a dead invite OR a broken detector. Skip the transient

--- a/.github/workflows/check-slack-invite.yml
+++ b/.github/workflows/check-slack-invite.yml
@@ -13,6 +13,12 @@ on:
     # Daily at 13:00 UTC. So a dead link is caught within ~24h, not weeks later.
     - cron: "0 13 * * *"
   workflow_dispatch:
+  # TEMPORARY: lets us test the monitor on this branch before merging.
+  # REMOVE this push trigger before merging — the monitor should only run on a
+  # schedule / manual dispatch, not on every push.
+  push:
+    branches:
+      - slack-invite-rotate-and-monitor
 
 concurrency:
   group: check-slack-invite

--- a/.github/workflows/check-slack-invite.yml
+++ b/.github/workflows/check-slack-invite.yml
@@ -10,8 +10,9 @@ name: Check Slack Invite
 
 on:
   schedule:
-    # Daily at 13:00 UTC. So a dead link is caught within ~24h, not weeks later.
-    - cron: "0 13 * * *"
+    # 1 PM PST (21:00 UTC), weekdays. GitHub cron is UTC-only with no DST, so
+    # this lands at 2 PM during PDT.
+    - cron: "0 21 * * 1-5"
   workflow_dispatch:
 
 concurrency:
@@ -31,9 +32,6 @@ jobs:
       image: mcr.microsoft.com/playwright:v1.49.1-jammy
     # A hung page-load should fail loudly, not sit there for the 6h default.
     timeout-minutes: 10
-    outputs:
-      status: ${{ steps.probe.outputs.status }}
-      reason: ${{ steps.probe.outputs.reason }}
 
     steps:
       - name: Checkout Git Repository
@@ -70,43 +68,33 @@ jobs:
           if-no-files-found: ignore
           retention-days: 7
 
-  # Ping Slack when the probe job fails (dead invite or broken detector). The
-  # "inconclusive" network case exits 0, so the probe job stays green and this
-  # won't fire. Mirrors the notify-slack pattern in terraform-paradedb-byoc.
-  notify-slack:
-    name: Notify Slack on Failure
-    needs: [check-slack-invite]
-    if: always() && needs.check-slack-invite.result == 'failure'
-    runs-on: ubuntu-latest
-    env:
-      SLACK_WEBHOOK_URL: ${{ secrets.SLACK_GITHUB_CHANNEL_WEBHOOK_URL }}
-      # Via env (not inline ${{ }}) so quotes in the reason can't break the shell.
-      MONITOR_STATUS: ${{ needs.check-slack-invite.outputs.status }}
-      MONITOR_REASON: ${{ needs.check-slack-invite.outputs.reason }}
-    steps:
-      - name: Send Slack notification
+      - name: Ping Slack on failure
+        # Fires for dead/detector_broken only; "inconclusive" exits 0 so it won't fire.
+        if: always() && (steps.probe.outputs.status == 'dead' || steps.probe.outputs.status == 'detector_broken')
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_GITHUB_CHANNEL_WEBHOOK_URL }}
+          # Via env (not inline ${{ }}) so quotes in the reason can't break the shell.
+          MONITOR_STATUS: ${{ steps.probe.outputs.status }}
+          MONITOR_REASON: ${{ steps.probe.outputs.reason }}
+          REPO: ${{ github.repository }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         run: |
           if [ -z "$SLACK_WEBHOOK_URL" ]; then
             echo "SLACK_GITHUB_CHANNEL_WEBHOOK_URL not set — skipping Slack ping."
             exit 0
           fi
-          run_url="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
-          # jq builds the payload so embedded quotes in the reason are escaped.
-          payload="$(jq -n \
-            --arg status "$MONITOR_STATUS" \
-            --arg reason "$MONITOR_REASON" \
-            --arg repo "${{ github.repository }}" \
-            --arg url "$run_url" \
-            '{
-              text: "🚨 ParadeDB Community Slack invite needs attention - <!here>",
-              attachments: [{
-                color: "danger",
-                fields: [
-                  {title: "Status", value: $status, short: true},
-                  {title: "Repository", value: $repo, short: true},
-                  {title: "Details", value: $reason, short: false},
-                  {title: "View Logs", value: ("<" + $url + "|Click here>"), short: false}
-                ]
-              }]
-            }')"
+          # node (already in the image) builds the JSON so quotes in the reason
+          # are escaped — no jq dependency needed.
+          payload="$(node -e 'process.stdout.write(JSON.stringify({
+            text: "🚨 ParadeDB Community Slack invite needs attention - <!here>",
+            attachments: [{
+              color: "danger",
+              fields: [
+                { title: "Status", value: process.env.MONITOR_STATUS, short: true },
+                { title: "Repository", value: process.env.REPO, short: true },
+                { title: "Details", value: process.env.MONITOR_REASON, short: false },
+                { title: "View Logs", value: `<${process.env.RUN_URL}|Click here>`, short: false }
+              ]
+            }]
+          }))')"
           curl -fsS -X POST -H 'Content-type: application/json' --data "$payload" "$SLACK_WEBHOOK_URL"

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -102,11 +102,16 @@ const nextConfig = {
         permanent: true,
       },
       // --- external service redirects ---
+      // NOTE: Slack shared invite links auto-deactivate after ~400 joins,
+      // regardless of the "never expire" setting. When this link dies, generate
+      // a new invite in the Slack admin and swap the destination below — every
+      // reference across the org points at /slack, so this is the only edit needed.
+      // Kept as `permanent: false` (302) so browsers/Slack don't cache a dead link.
       {
         source: "/slack",
         destination:
-          "https://join.slack.com/t/paradedbcommunity/shared_invite/zt-32abtyjg4-yoYoi~RPh9MSW8tDbl0BQw",
-        permanent: true,
+          "https://join.slack.com/t/paradedbcommunity/shared_invite/zt-40nbq9zkk-ffd5IvYjkMwnIx8MuPkFlQ",
+        permanent: false,
       },
       // --- legacy legal page redirects ---
       {


### PR DESCRIPTION
## What

The community Slack invite at `paradedb.com/slack` expired. Slack shared-invite links auto-deactivate after ~400 joins regardless of the "never expire" setting, and they fail **silently** — an expired link still returns 200 with a JS app-shell byte-identical to a live one, so curl/uptime checks can't catch it.

## Changes

- **`next.config.mjs`** — point `/slack` at the fresh invite and switch it to a **302** (`permanent: false`) so browsers/Slack don't cache a dead link.
- **`.github/workflows/check-slack-invite.yml`** + **`.github/scripts/check-slack-invite.mjs`** — a daily (and on-demand) `Check Slack Invite` job that:
  - renders `paradedb.com/slack` in headless Chromium and reads the post-JS DOM (the only way to detect Slack's client-side "no longer active" state),
  - re-checks a known-dead **canary** link each run so a Slack wording change surfaces as a `detector_broken` alert instead of silent false-"healthy",
  - on a dead link / broken detector, fails the run and opens a **de-duped GitHub issue**; uploads screenshots of both pages as artifacts,
  - installs Playwright in an isolated temp dir so it never touches the pnpm `package.json`/lockfile.

## When it fires

Generate a new invite in the Slack admin, then swap the `/slack` `destination` in `next.config.mjs`.

## Testing

After merge (or on this branch), run it manually via **Actions → Check Slack Invite → Run workflow** — it should report `healthy` against the new link.