### PR TITLE
fix: Redirect legacy /pages/<slug> blog URLs cleanly

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -59,6 +59,15 @@ const nextConfig = {
         destination: "https://www.paradedb.com/blog",
         permanent: true,
       },
+      // The legacy blog hosted posts at blog.paradedb.com/pages/<slug>. New
+      // posts live at www.paradedb.com/blog/<slug> with no `pages` segment, so
+      // strip it here (this must precede the catch-all below to take priority).
+      {
+        source: "/pages/:path*",
+        has: [{ type: "host", value: "blog.paradedb.com" }],
+        destination: "https://www.paradedb.com/blog/:path*",
+        permanent: true,
+      },
       {
         source: "/:path*",
         has: [{ type: "host", value: "blog.paradedb.com" }],
@@ -122,6 +131,15 @@ const nextConfig = {
       {
         source: "/terms",
         destination: "/legal/terms",
+        permanent: true,
+      },
+      // --- legacy blog path structure ---
+      // Catches any cached/direct hits to the old /pages/ structure that may
+      // have been recorded as www.paradedb.com/blog/pages/<slug> before the
+      // host rule above existed.
+      {
+        source: "/blog/pages/:path*",
+        destination: "/blog/:path*",
         permanent: true,
       },
       // --- specific post renames ---


### PR DESCRIPTION
# Ticket(s) Closed

None

## What

Add redirects so legacy `blog.paradedb.com/pages/<slug>` blog URLs resolve to their current `www.paradedb.com/blog/<slug>` location instead of 404ing.

## Why

The old blog hosted every post at `blog.paradedb.com/pages/<slug>` (e.g. the AGPL post shared on Hacker News: `blog.paradedb.com/pages/agpl`). The existing catch-all host rule rewrites `blog.paradedb.com/:path*` → `www.paradedb.com/blog/:path*`, which turns that into `www.paradedb.com/blog/pages/agpl` — a 404, since current posts have no `pages` segment. Every previously published post that anyone links to externally is broken the same way.

## How

**`next.config.mjs` — `redirects()`**

- Added a host-specific rule for `blog.paradedb.com` with `source: "/pages/:path*"` → `https://www.paradedb.com/blog/:path*`, placed **before** the existing `/:path*` catch-all so it takes priority. This strips the legacy `pages` segment in a single hop.
- Added a www-side guard `/blog/pages/:path*` → `/blog/:path*` to catch any previously-cached or direct hits already recorded under `www.paradedb.com/blog/pages/<slug>`.

Both are `permanent: true` (308), matching the surrounding blog redirects. Posts that were also renamed (e.g. `introducing_paradedb` → `introducing-paradedb`) chain cleanly through the existing per-post rules.

## Tests

- `next.config.mjs` loads without error and `prettier --check` passes.
- Verified the AGPL post resolves at `https://www.paradedb.com/blog/agpl` (live, 200).
- Traced redirect chain: `blog.paradedb.com/pages/agpl` → `www.paradedb.com/blog/agpl` (single hop via new host rule); cached `www.paradedb.com/blog/pages/agpl` → `www.paradedb.com/blog/agpl` via guard rule.
