### PR TITLE
feat: Sticky top nav with full-width background

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -120,7 +120,7 @@ export default function RootLayout({
           disableTransitionOnChange
         >
           <SiteBanner />
-          <div className="relative mx-auto w-full max-w-[1440px]">
+          <div className="sticky top-0 z-50 mx-auto w-full max-w-[1440px]">
             <Navigation />
           </div>
           {children}

--- a/src/components/ui/Navbar.tsx
+++ b/src/components/ui/Navbar.tsx
@@ -92,18 +92,27 @@ export function Navigation() {
         isHomePage ? "absolute top-0" : "relative h-16 md:h-20",
       )}
     >
+      {/* Full-viewport background — extends the nav bg past the 1440px wrapper */}
+      <div
+        className={cx(
+          "absolute inset-y-0 left-1/2 -translate-x-1/2 w-screen pointer-events-none",
+          open ? "h-auto" : "h-16 md:h-20",
+          isHomePage ? "bg-indigo-600" : "bg-white dark:bg-slate-950",
+        )}
+        aria-hidden="true"
+      />
       <header
         className={cx(
           "z-50 flex transform-gpu opacity-0 animate-navbar justify-center overflow-hidden transition-all duration-300 ease-[cubic-bezier(0.16,1,0.3,1.03)] will-change-transform",
           "left-4 md:left-12 right-4 md:right-12 absolute border-b",
           isHomePage
             ? "border-white/20"
-            : "border-slate-200 dark:border-slate-900 bg-white/80 dark:bg-slate-950/80 backdrop-blur-md",
+            : "border-slate-200 dark:border-slate-900",
           open === true
             ? "h-auto pb-8 pt-2 top-2 rounded-2xl"
             : "h-16 md:h-20 top-0",
           open === true
-            ? "bg-white/95 dark:bg-slate-950/95 backdrop-blur-2xl shadow-2xl shadow-black/10"
+            ? "bg-white dark:bg-slate-950 shadow-2xl shadow-black/10"
             : "bg-transparent",
         )}
       >


### PR DESCRIPTION
## Summary
- The top nav now sticks to the viewport so it stays visible as the user scrolls
- Background extends edge-to-edge (full viewport width) via an absolute layer behind the header content; the bg is solid indigo on landing routes and solid white elsewhere
- Removed the blur and translucent overlay (`bg-white/80 backdrop-blur-md`) so content doesn't bleed through the bar

## Test plan
- [ ] Hard-refresh the homepage at the top — nav should look the same as before (indigo, white logo, indigo links)
- [ ] Scroll down the homepage — nav stays pinned to the viewport top; bg remains indigo, content does not show through it
- [ ] Visit a non-landing page (e.g. /blog) — nav has solid white bg and sticks while scrolling
- [ ] Open the mobile menu on each — the card pops out with its existing white bg + shadow over the full-viewport bar