### PR TITLE
fix: pin Slack invite monitor to en-US locale

### DIFF
--- a/.github/scripts/check-slack-invite.mjs
+++ b/.github/scripts/check-slack-invite.mjs
@@ -83,8 +83,7 @@ const browser = await chromium.launch();
 // Pin the locale to English. Slack localizes these invite pages by request
 // geo/IP, so a runner in a non-English region renders e.g. "Ce lien n'est plus
 // actif" instead of "This link is no longer active" — and our English-only
-// DEAD_PHRASES never match, silently breaking detection (the canary then reads
-// "alive" and the job fails as detector_broken).
+// DEAD_PHRASES never match, silently breaking detection.
 const context = await browser.newContext({
   locale: "en-US",
   extraHTTPHeaders: { "Accept-Language": "en-US,en;q=0.9" },

--- a/.github/scripts/check-slack-invite.mjs
+++ b/.github/scripts/check-slack-invite.mjs
@@ -41,10 +41,10 @@ const DEAD_PHRASES = [
   "ask for a new link",
 ];
 
-async function classify(browser, label, url, screenshotPath) {
+async function classify(context, label, url, screenshotPath) {
   const t0 = Date.now();
   console.log(`[${label}] loading ${url} ...`);
-  const page = await browser.newPage();
+  const page = await context.newPage();
   try {
     // domcontentloaded + settle is more reliable than networkidle here: Slack
     // holds long-lived connections, so networkidle frequently times out.
@@ -64,7 +64,9 @@ async function classify(browser, label, url, screenshotPath) {
     );
     return { dead, matched, error: null };
   } catch (err) {
-    console.log(`[${label}] errored after ${Date.now() - t0}ms: ${err.message}`);
+    console.log(
+      `[${label}] errored after ${Date.now() - t0}ms: ${err.message}`,
+    );
     return { dead: null, matched: null, error: err.message };
   } finally {
     await page.close();
@@ -78,12 +80,21 @@ function setOutput(key, value) {
 }
 
 const browser = await chromium.launch();
+// Pin the locale to English. Slack localizes these invite pages by request
+// geo/IP, so a runner in a non-English region renders e.g. "Ce lien n'est plus
+// actif" instead of "This link is no longer active" — and our English-only
+// DEAD_PHRASES never match, silently breaking detection (the canary then reads
+// "alive" and the job fails as detector_broken).
+const context = await browser.newContext({
+  locale: "en-US",
+  extraHTTPHeaders: { "Accept-Language": "en-US,en;q=0.9" },
+});
 let status; // healthy | dead | detector_broken | inconclusive
 let reason;
 
 try {
-  const canary = await classify(browser, "canary", DEAD_CANARY, "canary.png");
-  const live = await classify(browser, "live", LIVE_URL, "live.png");
+  const canary = await classify(context, "canary", DEAD_CANARY, "canary.png");
+  const live = await classify(context, "live", LIVE_URL, "live.png");
 
   console.log("Canary (known-dead) result:", JSON.stringify(canary));
   console.log("Live  (paradedb.com/slack) result:", JSON.stringify(live));


### PR DESCRIPTION
# Ticket(s) Closed

None

## What

Pin the Slack invite health-check browser to the `en-US` locale so Slack always renders the English wording the dead-link detector expects.

## Why

The **Check Slack Invite** job [failed](https://github.com/paradedb/website/actions/runs/28058480737/job/83075041937) with `STATUS: detector_broken`:

```
Canary (known-dead) result: {"dead":false,"matched":null,"error":null}
STATUS: detector_broken
```

The monitor loads a deliberately known-dead "canary" invite each run and asserts the detector still flags it as dead; if the canary ever reads "alive" it intentionally fails the job so we never get a silent false "all healthy."

Root cause: Slack localizes its shared-invite pages by request geo/IP, and the script created pages with no locale. On the runner the dead page rendered in another language (reproduced locally as French — `"Ce lien n'est plus actif"`), while `DEAD_PHRASES` only contains English strings like `"no longer active"`. Nothing matched, so the dead link looked alive → `detector_broken`.

## How

**`.github/scripts/check-slack-invite.mjs`**

- After `chromium.launch()`, create a `browser.newContext({ locale: "en-US", extraHTTPHeaders: { "Accept-Language": "en-US,en;q=0.9" } })` and run both probes through it.
- `classify()` now takes the `context` and calls `context.newPage()` instead of `browser.newPage()`.
- Added a comment explaining the geo/IP localization trap.

## Tests

- `npx prettier --check` passes on the edited file.
- Ran the patched script locally against the real canary + live URLs:
  - Canary → `{"dead":true,"matched":"no longer active"}`
  - Live → `alive`
  - `STATUS: healthy`, exit 0
