### PR TITLE
feat: Animated pixel-shadow + diagram/section refinements

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -742,6 +742,7 @@ a {
   );
 }
 
+
 .dark {
   --color-background: #020617;
   --color-foreground: #f8fafc;

--- a/src/components/ui/Architecture.tsx
+++ b/src/components/ui/Architecture.tsx
@@ -1,23 +1,20 @@
+import type { ReactNode } from "react";
+import {
+  RiBarChart2Line,
+  RiBubbleChartLine,
+  RiSearchLine,
+} from "@remixicon/react";
 import { Badge } from "./Badge";
+import PixelShadow from "./PixelShadow";
+
+const SHADOW_INDIGO = "#4f46e5";
+const SHADOW_SLATE = "#64748b";
 
 export default function Architecture() {
-  const pixelShadow = (color: string) => ({
-    backgroundImage: `url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='5' height='5'%3E%3Crect width='2' height='2' fill='%23${color}' fill-opacity='0.5'/%3E%3C/svg%3E")`,
-    backgroundSize: "5px 5px",
-    backgroundPosition: "calc(100% + 3px) calc(100% + 3px)",
-  });
-
-  const indigoShadowStyle = pixelShadow("4f46e5");
-  const slateShadowStyle = pixelShadow("64748b");
-
   const tableBox = (
     <div className="relative">
-      <div
-        className="absolute top-2.5 left-2.5 -right-2.5 -bottom-2.5"
-        aria-hidden="true"
-        style={slateShadowStyle}
-      />
-      <div className="relative border-2 border-slate-500 dark:border-slate-500 bg-white dark:bg-slate-900 px-5 py-3">
+      <PixelShadow color={SHADOW_SLATE} />
+      <div className="relative border-2 border-slate-500 dark:border-slate-500 bg-white dark:bg-slate-900 px-5 py-3 text-center">
         <span className="font-mono font-bold text-slate-900 dark:text-white whitespace-nowrap text-sm sm:text-base">
           Table
         </span>
@@ -27,29 +24,47 @@ export default function Architecture() {
 
   const indexBox = (
     <div className="relative">
-      <div
-        className="absolute top-2.5 left-2.5 -right-2.5 -bottom-2.5"
-        aria-hidden="true"
-        style={indigoShadowStyle}
-      />
-      <div className="relative border-2 border-indigo-600 dark:border-indigo-400 bg-white dark:bg-slate-900 px-5 py-3 text-center">
-        <span className="font-mono font-bold text-indigo-600 dark:text-indigo-400 whitespace-nowrap text-sm sm:text-base">
+      <PixelShadow color={SHADOW_INDIGO} />
+      <div className="relative border-2 border-indigo-600 bg-indigo-600 px-5 py-3 text-center">
+        <div
+          aria-hidden="true"
+          className="absolute inset-0.5 border border-white/60 dark:border-white/30 pointer-events-none"
+        />
+        <span className="relative flex items-center justify-center gap-2 font-mono font-bold text-white whitespace-nowrap text-sm sm:text-base">
+          <img
+            src="/brand/paradedb-logomark-white.svg"
+            alt=""
+            className="h-[0.8em] w-auto"
+          />
           ParadeDB Index
         </span>
       </div>
     </div>
   );
 
-  const workloadLabels = ["Full-Text", "Vectors", "Aggregates"];
-  const renderWorkloadBox = (label: string) => (
+  const workloads: { label: string; icon: ReactNode }[] = [
+    { label: "Full-Text", icon: <RiSearchLine className="size-4 shrink-0" /> },
+    {
+      label: "Vectors",
+      icon: <RiBubbleChartLine className="size-4 shrink-0" />,
+    },
+    {
+      label: "Aggregates",
+      icon: <RiBarChart2Line className="size-4 shrink-0" />,
+    },
+  ];
+  const renderWorkloadBox = ({
+    label,
+    icon,
+  }: {
+    label: string;
+    icon: ReactNode;
+  }) => (
     <div key={label} className="relative">
-      <div
-        className="absolute top-2.5 left-2.5 -right-2.5 -bottom-2.5"
-        aria-hidden="true"
-        style={indigoShadowStyle}
-      />
-      <div className="relative border-2 border-indigo-600 dark:border-indigo-400 bg-white dark:bg-slate-900 px-3 py-3 text-center">
-        <span className="font-mono font-bold text-indigo-600 dark:text-indigo-400 whitespace-nowrap text-sm sm:text-base">
+      <PixelShadow color={SHADOW_INDIGO} />
+      <div className="relative border-2 border-indigo-600 dark:border-indigo-400 bg-indigo-50 dark:bg-indigo-950 px-3 py-3 text-center">
+        <span className="flex items-center justify-center gap-2 font-mono font-bold text-indigo-600 dark:text-indigo-400 whitespace-nowrap text-sm sm:text-base">
+          {icon}
           {label}
         </span>
       </div>
@@ -63,7 +78,7 @@ export default function Architecture() {
       viewBox="0 0 14 40"
       fill="none"
       aria-hidden="true"
-      className="text-indigo-600 dark:text-indigo-400"
+      className="h-9 lg:h-10 w-auto text-indigo-600 dark:text-indigo-400"
     >
       <line
         x1="7"
@@ -102,22 +117,22 @@ export default function Architecture() {
   const syncArrowVertical = (
     <svg
       width="14"
-      height="56"
-      viewBox="0 0 14 56"
+      height="40"
+      viewBox="0 0 14 40"
       fill="none"
       aria-hidden="true"
-      className="text-slate-500 dark:text-slate-400"
+      className="h-9 lg:h-10 w-auto text-slate-500 dark:text-slate-400"
     >
       <polygon points="7,0 2,10 12,10" fill="currentColor" />
       <line
         x1="7"
         y1="8"
         x2="7"
-        y2="48"
+        y2="32"
         stroke="currentColor"
         strokeWidth="2"
       />
-      <polygon points="7,56 2,46 12,46" fill="currentColor" />
+      <polygon points="7,40 2,30 12,30" fill="currentColor" />
     </svg>
   );
 
@@ -161,45 +176,55 @@ export default function Architecture() {
                 className="font-mono"
               >
                 {/* PostgreSQL frame: label inside, border around the whole diagram */}
-                <div className="relative border border-t-0 xl:border-x-0 border-slate-200 dark:border-slate-900 bg-white dark:bg-slate-950 px-5 pt-12 pb-10 sm:px-8 sm:pt-14 sm:pb-12 md:px-10 md:pt-[4.5rem] md:pb-16">
-                  {/* PostgreSQL label straddling the top border */}
-                  <div className="absolute inset-x-0 top-0 -translate-y-1/2 flex items-center gap-3 font-mono text-sm font-bold text-slate-400 dark:text-slate-500">
-                    <span aria-hidden className="h-px flex-1 bg-slate-200 dark:bg-slate-900" />
-                    PostgreSQL
-                    <span aria-hidden className="h-px flex-1 bg-slate-200 dark:bg-slate-900" />
-                  </div>
-                  <div className="max-w-[820px] mx-auto">
-                    {/* Mobile/tablet layout (< lg): vertical stack */}
-                    <div className="lg:hidden flex flex-col items-stretch gap-3">
-                      <div className="flex justify-center">{tableBox}</div>
-                      <div className="flex justify-center">
-                        {syncArrowVertical}
-                      </div>
-                      {indexBox}
-                      <div className="flex justify-center">{downArrow}</div>
-                      <div className="flex flex-col items-stretch gap-3">
-                        {workloadLabels.map(renderWorkloadBox)}
-                      </div>
+                <div className="relative border xl:border-x-0 border-slate-200 dark:border-slate-900 p-4 sm:p-5 md:p-6">
+                  {/* Inner frame: PostgreSQL label straddling its top border */}
+                  <div className="relative border border-t-0 border-slate-200 dark:border-slate-900 bg-white dark:bg-slate-950 px-5 pt-12 pb-10 sm:px-8 sm:pt-14 sm:pb-12 md:px-10 md:pt-[4.5rem] md:pb-16">
+                    <div className="absolute inset-x-0 top-0 -translate-y-1/2 flex items-center gap-3 font-mono text-sm font-bold text-slate-900 dark:text-white">
+                      <span
+                        aria-hidden
+                        className="h-px flex-1 bg-slate-200 dark:bg-slate-900"
+                      />
+                      PostgreSQL
+                      <span
+                        aria-hidden
+                        className="h-px flex-1 bg-slate-200 dark:bg-slate-900"
+                      />
                     </div>
-
-                    {/* Desktop layout (lg+): horizontal grid */}
-                    <div className="hidden lg:grid gap-x-6 items-center grid-cols-[auto_auto_1fr]">
-                      {tableBox}
-                      {syncArrowHorizontal}
-                      {indexBox}
-                      <div />
-                      <div />
-                      <div className="grid grid-cols-3 gap-6 mt-[22px] mb-3 justify-items-center">
-                        {[1, 2, 3].map((i) => (
-                          <span key={i} className="inline-flex">
-                            {downArrow}
-                          </span>
-                        ))}
+                    <div className="max-w-[820px] mx-auto">
+                      {/* Mobile/tablet layout (< lg): vertical stack */}
+                      <div className="lg:hidden flex flex-col items-stretch gap-3">
+                        {tableBox}
+                        <div className="flex justify-center mt-3">
+                          {syncArrowVertical}
+                        </div>
+                        {indexBox}
+                        <div className="flex justify-center mt-3">
+                          {downArrow}
+                        </div>
+                        <div className="flex flex-col items-stretch gap-5">
+                          {workloads.map(renderWorkloadBox)}
+                        </div>
                       </div>
-                      <div />
-                      <div />
-                      <div className="grid grid-cols-3 gap-6">
-                        {workloadLabels.map(renderWorkloadBox)}
+
+                      {/* Desktop layout (lg+): horizontal grid */}
+                      <div className="hidden lg:grid gap-x-6 items-center grid-cols-[auto_auto_1fr]">
+                        {tableBox}
+                        {syncArrowHorizontal}
+                        {indexBox}
+                        <div />
+                        <div />
+                        <div className="grid grid-cols-3 gap-6 mt-[22px] mb-3 justify-items-center">
+                          {[1, 2, 3].map((i) => (
+                            <span key={i} className="inline-flex">
+                              {downArrow}
+                            </span>
+                          ))}
+                        </div>
+                        <div />
+                        <div />
+                        <div className="grid grid-cols-3 gap-6">
+                          {workloads.map(renderWorkloadBox)}
+                        </div>
                       </div>
                     </div>
                   </div>

--- a/src/components/ui/PixelShadow.tsx
+++ b/src/components/ui/PixelShadow.tsx
@@ -1,0 +1,163 @@
+"use client";
+
+import { useEffect, useRef } from "react";
+
+const GRID = 4;
+const PIX = 2;
+// The offset strip is exactly 3 grid cells (12px) wide; this phase lands all
+// three pixel columns/rows fully inside it with symmetric margins and no clip.
+const OFFSET = 1;
+const LAYERS = 3; // pixel columns/rows that fit in the offset strip
+const STRIP = LAYERS * GRID; // width (px) of the offset shadow region
+// Opacity from the box's distance field: pixels within FADE_START px of the box
+// edge stay at MAX, then fade to 0 by FADE_END — tracing the box outline.
+const MAX_ALPHA = 1;
+const FADE_START = 3;
+const FADE_END = 14;
+const HIGHLIGHT = "#4f46e5"; // solid main indigo
+const FRAME_MS = 33;
+const SPAWN_MS = 220;
+
+// Canvas pixel shadow: a static grid of pixels anchored to the bottom-right
+// (matching the CSS pixel shadow), with a rotating random subset that smoothly
+// fades up to solid indigo and back.
+export default function PixelShadow({
+  color,
+  glow = false,
+}: {
+  color: string;
+  glow?: boolean;
+}) {
+  const ref = useRef<HTMLCanvasElement>(null);
+
+  useEffect(() => {
+    const canvas = ref.current;
+    if (!canvas) return;
+    const ctx = canvas.getContext("2d");
+    if (!ctx) return;
+
+    let cols = 0;
+    let rows = 0;
+    let w = 0;
+    let h = 0;
+    const active = new Map<number, { start: number; dur: number }>();
+    let lastSpawn = 0;
+
+    // Opacity from the box's signed distance field: max near the edge, fading
+    // outward by Euclidean distance so the shadow traces the box outline.
+    const alphaAt = (x: number, y: number) => {
+      const ddx = Math.max(0, x + PIX / 2 - (w - STRIP));
+      const ddy = Math.max(0, y + PIX / 2 - (h - STRIP));
+      const d = Math.sqrt(ddx * ddx + ddy * ddy);
+      const f = (FADE_END - d) / (FADE_END - FADE_START);
+      return MAX_ALPHA * Math.max(0, Math.min(1, f));
+    };
+
+    const sync = () => {
+      const dpr = window.devicePixelRatio || 1;
+      w = canvas.clientWidth;
+      h = canvas.clientHeight;
+      canvas.width = Math.max(1, Math.round(w * dpr));
+      canvas.height = Math.max(1, Math.round(h * dpr));
+      ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
+      cols = Math.ceil(w / GRID) + 1;
+      rows = Math.ceil(h / GRID) + 1;
+      active.clear();
+    };
+
+    const render = (now: number) => {
+      ctx.clearRect(0, 0, w, h);
+
+      // Prune finished pixels before the base pass so a just-completed pixel is
+      // redrawn at full base this frame (no one-frame gap / flicker).
+      for (const [idx, a] of active) {
+        if ((now - a.start) / a.dur >= 1) active.delete(idx);
+      }
+
+      ctx.fillStyle = color;
+      for (let r = 0; r < rows; r++) {
+        const y = Math.round(h + OFFSET - (r + 1) * GRID);
+        if (y + PIX > h) continue;
+        if (y < 0) break;
+        for (let c = 0; c < cols; c++) {
+          const x = Math.round(w + OFFSET - (c + 1) * GRID);
+          if (x + PIX > w) continue;
+          if (x < 0) break;
+          if (!glow && active.has(r * cols + c)) continue;
+          ctx.globalAlpha = alphaAt(x, y);
+          ctx.fillRect(x, y, PIX, PIX);
+        }
+      }
+
+      ctx.fillStyle = glow ? HIGHLIGHT : color;
+      for (const [idx, a] of active) {
+        const t = (now - a.start) / a.dur;
+        if (t >= 1) {
+          active.delete(idx);
+          continue;
+        }
+        const c = idx % cols;
+        const r = Math.floor(idx / cols);
+        const x = Math.round(w + OFFSET - (c + 1) * GRID);
+        const y = Math.round(h + OFFSET - (r + 1) * GRID);
+        if (x < 0 || y < 0 || x + PIX > w || y + PIX > h) continue;
+        ctx.globalAlpha = glow
+          ? // fade up to solid indigo, hold, then fade out
+            t < 0.25
+            ? t / 0.25
+            : t > 0.75
+              ? (1 - t) / 0.25
+              : 1
+          : // smoothly fade the pixel away and back
+            alphaAt(x, y) * (1 - Math.sin(t * Math.PI));
+        ctx.fillRect(x, y, PIX, PIX);
+      }
+      ctx.globalAlpha = 1;
+    };
+
+    sync();
+
+    const reduce = window.matchMedia(
+      "(prefers-reduced-motion: reduce)",
+    ).matches;
+    let timer: number | null = null;
+    if (reduce) {
+      render(0);
+    } else {
+      timer = window.setInterval(() => {
+        const now = performance.now();
+        if (now - lastSpawn > SPAWN_MS) {
+          lastSpawn = now;
+          const total = cols * rows;
+          const n = Math.max(1, Math.round(total * (glow ? 0.02 : 0.045)));
+          for (let i = 0; i < n; i++) {
+            const idx = Math.floor(Math.random() * total);
+            if (!active.has(idx))
+              active.set(idx, { start: now, dur: 1000 + Math.random() * 900 });
+          }
+        }
+        render(performance.now());
+      }, FRAME_MS);
+    }
+
+    const ro = new ResizeObserver(() => {
+      sync();
+      render(performance.now());
+    });
+    ro.observe(canvas);
+
+    return () => {
+      if (timer) clearInterval(timer);
+      ro.disconnect();
+    };
+  }, [color]);
+
+  return (
+    <div
+      aria-hidden="true"
+      className="absolute top-3 left-3 -right-3 -bottom-3"
+    >
+      <canvas ref={ref} className="block h-full w-full" />
+    </div>
+  );
+}

--- a/src/components/ui/PostgresNative.tsx
+++ b/src/components/ui/PostgresNative.tsx
@@ -109,7 +109,7 @@ export default function PostgresNative() {
 
           {/* Keeps bento */}
           <div className="px-4 md:px-12">
-            <div className="flex items-baseline gap-3 mb-6 px-2 md:px-0">
+            <div className="flex items-baseline gap-3 mb-6 px-2 md:px-0 max-w-[1128px] mx-auto">
               <span className="text-[10px] font-mono uppercase tracking-[0.18em] text-slate-500">
                 what you get
               </span>
@@ -119,7 +119,7 @@ export default function PostgresNative() {
               </span>
             </div>
 
-            <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-5 sm:gap-6 pr-2.5 pb-2.5">
+            <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-5 sm:gap-6 pr-2.5 pb-2.5 max-w-[1128px] mx-auto">
               {KEEPS.map((item, i) => {
                 const isWide = i === KEEPS.length - 1;
                 return (
@@ -138,12 +138,12 @@ export default function PostgresNative() {
                       className="absolute top-2.5 left-2.5 -right-2.5 -bottom-2.5"
                       aria-hidden="true"
                       style={{
-                        backgroundImage: `url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='5' height='5'%3E%3Crect width='2' height='2' fill='%234f46e5' fill-opacity='0.5'/%3E%3C/svg%3E")`,
+                        backgroundImage: `url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='5' height='5'%3E%3Crect width='2' height='2' fill='%2394a3b8' fill-opacity='0.5'/%3E%3C/svg%3E")`,
                         backgroundSize: "5px 5px",
                         backgroundPosition: "calc(100% + 3px) calc(100% + 3px)",
                       }}
                     />
-                    <div className="relative flex flex-col border-2 border-indigo-400 dark:border-indigo-500 px-6 py-7 md:px-7 md:py-8 bg-white dark:bg-slate-950 group h-full">
+                    <div className="relative flex flex-col border border-slate-200 dark:border-slate-800 px-6 py-7 md:px-7 md:py-8 bg-white dark:bg-slate-950 group h-full">
                       <div className="absolute top-3 right-3 font-mono text-[10px] text-slate-400 dark:text-slate-600">
                         0{i + 1}
                       </div>

--- a/src/components/ui/Pricing.tsx
+++ b/src/components/ui/Pricing.tsx
@@ -22,57 +22,48 @@ const PricingCard = ({
   badgeText: string;
 }) => (
   <div className="relative h-full">
-    <div
-      className="absolute top-2.5 left-2.5 -right-2.5 -bottom-2.5"
-      aria-hidden="true"
-      style={{
-        backgroundImage: `url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='5' height='5'%3E%3Crect width='2' height='2' fill='%234f46e5' fill-opacity='0.5'/%3E%3C/svg%3E")`,
-        backgroundSize: "5px 5px",
-        backgroundPosition: "calc(100% + 3px) calc(100% + 3px)",
-      }}
-    />
-    <div className="relative flex flex-col p-6 sm:p-8 md:p-12 h-full border-2 border-indigo-400 dark:border-indigo-500 bg-white dark:bg-slate-900 text-left items-start">
-    <div className="mb-6 sm:mb-8 w-full">
-      <div className="flex justify-start mb-2">
-        <Badge className="py-0.5 px-2 text-[10px]">{badgeText}</Badge>
+    <div className="relative flex flex-col p-6 sm:p-8 md:p-12 h-full bg-white dark:bg-slate-900 text-left items-start">
+      <div className="mb-6 sm:mb-8 w-full">
+        <div className="flex justify-start mb-2">
+          <Badge className="py-0.5 px-2 text-[10px]">{badgeText}</Badge>
+        </div>
+        <div className="flex items-baseline justify-start gap-1 mb-4">
+          <span className="text-2xl sm:text-3xl font-bold text-indigo-950 dark:text-white">
+            {planName}
+          </span>
+        </div>
+        <p className="text-sm text-slate-600 dark:text-slate-400 leading-relaxed">
+          {description}
+        </p>
       </div>
-      <div className="flex items-baseline justify-start gap-1 mb-4">
-        <span className="text-2xl sm:text-3xl font-bold text-indigo-950 dark:text-white">
-          {planName}
-        </span>
-      </div>
-      <p className="text-sm text-slate-600 dark:text-slate-400 leading-relaxed">
-        {description}
-      </p>
-    </div>
 
-    <ul className="space-y-4 mb-10 w-full text-left">
-      {features.map((feature, i) => (
-        <li
-          key={i}
-          className="flex items-start gap-3 text-sm text-slate-700 dark:text-slate-300"
-        >
-          <RiCheckLine className="size-5 text-indigo-600 dark:text-indigo-400 shrink-0" />
-          <span className="leading-tight">{feature}</span>
-        </li>
-      ))}
-    </ul>
+      <ul className="space-y-4 mb-10 w-full text-left">
+        {features.map((feature, i) => (
+          <li
+            key={i}
+            className="flex items-start gap-3 text-sm text-slate-700 dark:text-slate-300"
+          >
+            <RiCheckLine className="size-5 text-indigo-600 dark:text-indigo-400 shrink-0" />
+            <span className="leading-tight">{feature}</span>
+          </li>
+        ))}
+      </ul>
 
-    <Button
-      asChild
-      className="w-full h-12 rounded-none text-md font-semibold shadow-none mt-auto"
-      variant={buttonVariant as any}
-    >
-      <Link
-        href={buttonLink}
-        target={buttonLink.startsWith("mailto:") ? undefined : "_blank"}
-        rel={
-          buttonLink.startsWith("mailto:") ? undefined : "noopener noreferrer"
-        }
+      <Button
+        asChild
+        className="w-full h-12 rounded-none text-md font-semibold shadow-none mt-auto"
+        variant={buttonVariant as any}
       >
-        {buttonText}
-      </Link>
-    </Button>
+        <Link
+          href={buttonLink}
+          target={buttonLink.startsWith("mailto:") ? undefined : "_blank"}
+          rel={
+            buttonLink.startsWith("mailto:") ? undefined : "noopener noreferrer"
+          }
+        >
+          {buttonText}
+        </Link>
+      </Button>
     </div>
   </div>
 );
@@ -108,7 +99,7 @@ export default function Pricing() {
 
             {/* Nested Cards Container */}
             <div className="relative w-full z-20">
-              <div className="max-w-[1128px] mx-auto grid grid-cols-1 md:grid-cols-3 gap-5 sm:gap-6 pr-2.5 pb-2.5">
+              <div className="max-w-[1128px] mx-auto grid grid-cols-1 md:grid-cols-3 border-y border-slate-200 dark:border-slate-800 divide-y md:divide-y-0 md:divide-x divide-slate-200 dark:divide-slate-800">
                 <PricingCard
                   planName="Community"
                   badgeText="Self-Managed"


### PR DESCRIPTION
## Summary
Adds an animated pixel-shadow to the Architecture diagram and refines several sections.

### New: `PixelShadow` canvas component (`src/components/ui/PixelShadow.tsx`)
- Renders the box pixel-shadow on a `<canvas>` anchored to the bottom-right.
- Opacity comes from the box's **distance field** — dots within a few px of the edge stay at full opacity (tracing the outline), fading to 0 outward (Euclidean SDF → rounded corner).
- A rotating random subset of pixels **smoothly fades away and back**.
- 2px pixels on a 4px grid, exactly three clean layers in the offset strip with no clipping.
- Respects `prefers-reduced-motion` (renders static) and resizes via `ResizeObserver`.

### Architecture diagram (`Architecture.tsx`)
- Hero-styled **ParadeDB Index** (solid indigo, logomark, inset border), workload cards with icons + tint, nested PostgreSQL frame with the label straddling the inner border.
- Mobile: full-width Table, equal/shorter arrows, and spacing so the shadows don't crowd the arrows or workload cards.

### Other sections
- **PostgresNative** cards: gray borders + slate shadow; section bounded to the standard `max-w-[1128px]`.
- **Pricing** cards: removed the pixel shadow, restored the flush divided-grid layout with gray borders.

## Verification
Built/verified locally against the running dev server (canvas render + animation confirmed via pixel-data sampling, since the in-app preview's headless renderer freezes animation frames). No console/compile errors.