### PR TITLE
fix: launch real Chrome in Slack invite monitor to beat bot wall

### DIFF
--- a/.github/scripts/check-slack-invite.mjs
+++ b/.github/scripts/check-slack-invite.mjs
@@ -1,32 +1,27 @@
 // .github/scripts/check-slack-invite.mjs
 //
 // Health-check the public Slack invite redirect (https://paradedb.com/slack).
+// Dead and live invites both return a byte-identical 200 app-shell and render
+// "valid" vs "no longer active" client-side, so we load the page in a browser
+// and read the DOM rather than curling.
 //
-// Why a headless browser and not curl: Slack shared-invite links render their
-// "valid" vs "no longer active" state CLIENT-SIDE in JavaScript. A dead link and
-// a live link return a byte-identical HTML app-shell with a 200 status, so curl /
-// uptime pings cannot tell them apart. We must load the page and read the DOM
-// after the SPA has rendered.
-//
-// Slack invite links auto-deactivate after ~400 joins regardless of the
-// "never expire" setting, so this WILL fire periodically. When it does, generate
-// a new invite in the Slack admin and swap the destination in next.config.mjs.
+// Invites auto-deactivate after ~400 joins regardless of the "never expire"
+// setting, so this WILL fire periodically. Then generate a new invite in the
+// Slack admin and swap the destination in next.config.mjs.
 
 import { chromium } from "playwright";
 import { appendFileSync } from "node:fs";
 
 const LIVE_URL = "https://paradedb.com/slack";
 
-// A known-DEAD invite, kept as a calibration canary. Every run we assert the
-// detector still flags this as dead. If it ever reads "alive", Slack changed
-// their page wording and our detection is silently broken — which is its own
-// alert-worthy failure (otherwise we'd get false "all healthy" forever).
+// A known-DEAD invite kept as a calibration canary: every run must flag it as
+// dead. If it reads "alive", detection is silently broken (own alert below).
 const DEAD_CANARY =
   "https://join.slack.com/t/paradedbcommunity/shared_invite/zt-32abtyjg4-yoYoi~RPh9MSW8tDbl0BQw";
 
-// Phrases Slack shows on an expired/invalid shared invite. Lowercased substring
-// match against the rendered page text. Broad on purpose — a false "dead" just
-// triggers a manual look, whereas a missed death blocks new users silently.
+// Lowercased substrings Slack shows on an expired/invalid invite. Broad on
+// purpose — a false "dead" just triggers a manual look; a missed death blocks
+// new users silently.
 const DEAD_PHRASES = [
   "no longer active",
   "isn't active",
@@ -41,14 +36,8 @@ const DEAD_PHRASES = [
   "ask for a new link",
 ];
 
-// Slack gates these invite pages behind a browser-support check. It 403s any
-// client whose User-Agent Client Hints brand isn't "Google Chrome" and serves
-// a "your browser is not supported" interstitial instead of the real invite
-// content — silently breaking detection. We launch real Google Chrome (see the
-// launch call below) to get past it; this phrase lets us detect (and clearly
-// report) a regression if Slack blocks us anyway. Do NOT set a custom
-// userAgent on the context: Playwright derives the client-hint brand from it,
-// which reintroduces the non-"Google Chrome" brand and gets us blocked again.
+// Shown when Slack's bot wall blocks us (see the launch call). Detecting it
+// lets us report a clear regression instead of a bogus "alive".
 const UNSUPPORTED_BROWSER_PHRASE = "your browser is not supported";
 
 async function classify(context, label, url, screenshotPath) {
@@ -56,8 +45,7 @@ async function classify(context, label, url, screenshotPath) {
   console.log(`[${label}] loading ${url} ...`);
   const page = await context.newPage();
   try {
-    // domcontentloaded + settle is more reliable than networkidle here: Slack
-    // holds long-lived connections, so networkidle frequently times out.
+    // networkidle times out (Slack holds long-lived connections), so settle.
     await page.goto(url, { waitUntil: "domcontentloaded", timeout: 45000 });
     console.log(`[${label}] loaded, settling for render ...`);
     await page.waitForTimeout(5000);
@@ -68,8 +56,7 @@ async function classify(context, label, url, screenshotPath) {
       await page.evaluate(() => document.body.innerText || "")
     ).toLowerCase();
     if (text.includes(UNSUPPORTED_BROWSER_PHRASE)) {
-      // Slack blocked us at the browser gate — we never saw the real invite
-      // page, so neither "dead" nor "alive" is trustworthy. Surface it.
+      // Blocked before the real invite page — neither dead nor alive is trusted.
       console.log(
         `[${label}] done in ${Date.now() - t0}ms — BLOCKED (unsupported-browser page)`,
       );
@@ -97,18 +84,13 @@ function setOutput(key, value) {
   }
 }
 
-// Launch real Google Chrome (channel: "chrome"), NOT bundled headless Chromium.
-// Slack now gates the invite pages behind bot detection that 403s any client
-// whose User-Agent Client Hints brand isn't "Google Chrome" — headless Chromium
-// reports "HeadlessChrome"/"Chromium" and gets served a "your browser is not
-// supported" interstitial instead of the real valid/expired invite content.
-// Google Chrome reports the "Google Chrome" brand and is let through. The CI
-// workflow installs this channel before running (see check-slack-invite.yml).
+// Real Google Chrome, NOT bundled headless Chromium. Slack's bot wall 403s any
+// client whose Client Hints brand isn't "Google Chrome" (Chromium reports
+// "HeadlessChrome"/"Chromium") and serves the unsupported-browser page instead
+// of the invite. The CI workflow installs this channel (see the .yml). Don't
+// set a custom userAgent — Playwright derives the brand from it and re-blocks.
 const browser = await chromium.launch({ channel: "chrome" });
-// Pin the locale to English. Slack localizes these invite pages by request
-// geo/IP, so a runner in a non-English region renders e.g. "Ce lien n'est plus
-// actif" instead of "This link is no longer active" — and our English-only
-// DEAD_PHRASES never match, silently breaking detection.
+// Pin English: Slack localizes by geo/IP, and our DEAD_PHRASES are English-only.
 const context = await browser.newContext({
   locale: "en-US",
   extraHTTPHeaders: { "Accept-Language": "en-US,en;q=0.9" },
@@ -124,11 +106,7 @@ try {
   console.log("Live  (paradedb.com/slack) result:", JSON.stringify(live));
 
   if (canary.blocked || live.blocked) {
-    // Slack served the "your browser is not supported" interstitial instead of
-    // the real invite page — we never reached the content we classify on, so
-    // the detector is blind. Likely Slack tightened its browser gate; confirm
-    // the probe is still launching real Google Chrome (channel: "chrome") and
-    // not falling back to headless Chromium.
+    // Hit the bot wall — detector is blind. Slack likely tightened the gate.
     status = "detector_broken";
     reason =
       "Slack served its 'your browser is not supported' page instead of the " +
@@ -137,7 +115,7 @@ try {
       ".github/scripts/check-slack-invite.mjs and that Chrome is installed in CI. " +
       "Until fixed, this monitor cannot be trusted to catch a real outage.";
   } else if (canary.dead !== true) {
-    // The detector can no longer recognize a link it MUST recognize as dead.
+    // Canary not flagged dead — Slack likely changed their expired-page wording.
     status = "detector_broken";
     reason =
       "The known-dead canary link was NOT detected as dead. Slack likely changed " +
@@ -166,9 +144,7 @@ setOutput("reason", reason);
 
 console.log(`\nSTATUS: ${status}\n${reason}`);
 
-// Fail the job for actionable states (dead invite, broken detector) so the run
-// goes red and surfaces in the Actions UI / email. "inconclusive" (transient
-// network) does not fail — it just logs and retries next run.
+// Fail only on actionable states. "inconclusive" (transient network) retries.
 if (status === "dead" || status === "detector_broken") {
   process.exitCode = 1;
 }

--- a/.github/scripts/check-slack-invite.mjs
+++ b/.github/scripts/check-slack-invite.mjs
@@ -41,6 +41,16 @@ const DEAD_PHRASES = [
   "ask for a new link",
 ];
 
+// Slack gates these invite pages behind a browser-support check. It 403s any
+// client whose User-Agent Client Hints brand isn't "Google Chrome" and serves
+// a "your browser is not supported" interstitial instead of the real invite
+// content — silently breaking detection. We launch real Google Chrome (see the
+// launch call below) to get past it; this phrase lets us detect (and clearly
+// report) a regression if Slack blocks us anyway. Do NOT set a custom
+// userAgent on the context: Playwright derives the client-hint brand from it,
+// which reintroduces the non-"Google Chrome" brand and gets us blocked again.
+const UNSUPPORTED_BROWSER_PHRASE = "your browser is not supported";
+
 async function classify(context, label, url, screenshotPath) {
   const t0 = Date.now();
   console.log(`[${label}] loading ${url} ...`);
@@ -57,17 +67,25 @@ async function classify(context, label, url, screenshotPath) {
     const text = (
       await page.evaluate(() => document.body.innerText || "")
     ).toLowerCase();
+    if (text.includes(UNSUPPORTED_BROWSER_PHRASE)) {
+      // Slack blocked us at the browser gate — we never saw the real invite
+      // page, so neither "dead" nor "alive" is trustworthy. Surface it.
+      console.log(
+        `[${label}] done in ${Date.now() - t0}ms — BLOCKED (unsupported-browser page)`,
+      );
+      return { dead: null, matched: null, error: null, blocked: true };
+    }
     const matched = DEAD_PHRASES.find((p) => text.includes(p)) || null;
     const dead = Boolean(matched);
     console.log(
       `[${label}] done in ${Date.now() - t0}ms — ${dead ? `DEAD (matched "${matched}")` : "alive"}`,
     );
-    return { dead, matched, error: null };
+    return { dead, matched, error: null, blocked: false };
   } catch (err) {
     console.log(
       `[${label}] errored after ${Date.now() - t0}ms: ${err.message}`,
     );
-    return { dead: null, matched: null, error: err.message };
+    return { dead: null, matched: null, error: err.message, blocked: false };
   } finally {
     await page.close();
   }
@@ -79,7 +97,14 @@ function setOutput(key, value) {
   }
 }
 
-const browser = await chromium.launch();
+// Launch real Google Chrome (channel: "chrome"), NOT bundled headless Chromium.
+// Slack now gates the invite pages behind bot detection that 403s any client
+// whose User-Agent Client Hints brand isn't "Google Chrome" — headless Chromium
+// reports "HeadlessChrome"/"Chromium" and gets served a "your browser is not
+// supported" interstitial instead of the real valid/expired invite content.
+// Google Chrome reports the "Google Chrome" brand and is let through. The CI
+// workflow installs this channel before running (see check-slack-invite.yml).
+const browser = await chromium.launch({ channel: "chrome" });
 // Pin the locale to English. Slack localizes these invite pages by request
 // geo/IP, so a runner in a non-English region renders e.g. "Ce lien n'est plus
 // actif" instead of "This link is no longer active" — and our English-only
@@ -98,7 +123,20 @@ try {
   console.log("Canary (known-dead) result:", JSON.stringify(canary));
   console.log("Live  (paradedb.com/slack) result:", JSON.stringify(live));
 
-  if (canary.dead !== true) {
+  if (canary.blocked || live.blocked) {
+    // Slack served the "your browser is not supported" interstitial instead of
+    // the real invite page — we never reached the content we classify on, so
+    // the detector is blind. Likely Slack tightened its browser gate; confirm
+    // the probe is still launching real Google Chrome (channel: "chrome") and
+    // not falling back to headless Chromium.
+    status = "detector_broken";
+    reason =
+      "Slack served its 'your browser is not supported' page instead of the " +
+      "invite page, so neither link could be classified. Confirm the probe still " +
+      'launches real Google Chrome (channel: "chrome") in ' +
+      ".github/scripts/check-slack-invite.mjs and that Chrome is installed in CI. " +
+      "Until fixed, this monitor cannot be trusted to catch a real outage.";
+  } else if (canary.dead !== true) {
     // The detector can no longer recognize a link it MUST recognize as dead.
     status = "detector_broken";
     reason =

--- a/.github/workflows/check-slack-invite.yml
+++ b/.github/workflows/check-slack-invite.yml
@@ -1,11 +1,9 @@
 # workflows/check-slack-invite.yml
 #
 # Check Slack Invite
-# Alerts when the public Slack invite (https://paradedb.com/slack) dies. Slack
-# links auto-deactivate after ~400 joins and fail silently (an expired link
-# still 200s with a live-looking app-shell), so this renders the page in real
-# Google Chrome to detect it — Slack bot-blocks headless Chromium with a 403
-# "browser not supported" wall. See check-slack-invite.mjs for details.
+# Alerts when the public Slack invite (https://paradedb.com/slack) dies. Renders
+# the page in real Google Chrome (Slack bot-blocks headless Chromium) to detect
+# silently-expired invites. See check-slack-invite.mjs for details.
 
 name: Check Slack Invite
 
@@ -15,8 +13,7 @@ on:
     # this lands at 2 PM during PDT.
     - cron: "0 21 * * 1-5"
   workflow_dispatch:
-  # Run on PRs that touch the monitor itself so changes can be tested in CI
-  # before merge.
+  # Run on PRs that touch the monitor itself, to test before merge.
   pull_request:
     paths:
       - ".github/workflows/check-slack-invite.yml"
@@ -33,9 +30,8 @@ jobs:
   check-slack-invite:
     name: Check Slack Invite
     runs-on: ubuntu-latest
-    # Browser OS deps are baked in. We install real Google Chrome below (the
-    # image only ships headless Chromium, which Slack now bot-blocks). Keep the
-    # `playwright@` install below on the same version tag as the image.
+    # Image ships headless Chromium + OS deps; we install real Chrome below.
+    # Keep the `playwright@` install on the same version tag as the image.
     container:
       image: mcr.microsoft.com/playwright:v1.49.1-jammy
     # A hung page-load should fail loudly, not sit there for the 6h default.
@@ -48,17 +44,14 @@ jobs:
       - name: Probe Slack invite
         id: probe
         run: |
-          # Install only the Playwright JS package (seconds — no browser bytes;
-          # OS deps are already in the image). Isolated temp dir keeps us off
-          # the repo's pnpm package.json/lockfile.
+          # Install just the Playwright JS package (no browser bytes). Isolated
+          # temp dir keeps us off the repo's pnpm package.json/lockfile.
           mkdir -p "$RUNNER_TEMP/pw"
           cp .github/scripts/check-slack-invite.mjs "$RUNNER_TEMP/pw/probe.mjs"
           cd "$RUNNER_TEMP/pw"
           npm init -y >/dev/null 2>&1
           PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1 npm install playwright@1.49.1 >/dev/null
-          # Install real Google Chrome — the probe launches channel:"chrome" to
-          # get past Slack's bot wall (headless Chromium is served a 403). OS
-          # deps are baked into the image, so this is just the browser binary.
+          # Real Chrome — the probe launches channel:"chrome" to clear the bot wall.
           npx playwright install chrome >/dev/null
           # Don't let set -e abort on a failing probe — we still need to copy the
           # screenshots/reason back so the artifact + issue steps can use them.

--- a/.github/workflows/check-slack-invite.yml
+++ b/.github/workflows/check-slack-invite.yml
@@ -15,6 +15,12 @@ on:
     # this lands at 2 PM during PDT.
     - cron: "0 21 * * 1-5"
   workflow_dispatch:
+  # Run on PRs that touch the monitor itself so changes can be tested in CI
+  # before merge.
+  pull_request:
+    paths:
+      - ".github/workflows/check-slack-invite.yml"
+      - ".github/scripts/check-slack-invite.mjs"
 
 concurrency:
   group: check-slack-invite-${{ github.head_ref || github.ref }}

--- a/.github/workflows/check-slack-invite.yml
+++ b/.github/workflows/check-slack-invite.yml
@@ -13,7 +13,6 @@ on:
     # this lands at 2 PM during PDT.
     - cron: "0 21 * * 1-5"
   workflow_dispatch:
-  # Run on PRs that touch the monitor itself, to test before merge.
   pull_request:
     paths:
       - ".github/workflows/check-slack-invite.yml"

--- a/.github/workflows/check-slack-invite.yml
+++ b/.github/workflows/check-slack-invite.yml
@@ -3,8 +3,9 @@
 # Check Slack Invite
 # Alerts when the public Slack invite (https://paradedb.com/slack) dies. Slack
 # links auto-deactivate after ~400 joins and fail silently (an expired link
-# still 200s with a live-looking app-shell), so this renders the page in a
-# headless browser to detect it. See check-slack-invite.mjs for details.
+# still 200s with a live-looking app-shell), so this renders the page in real
+# Google Chrome to detect it — Slack bot-blocks headless Chromium with a 403
+# "browser not supported" wall. See check-slack-invite.mjs for details.
 
 name: Check Slack Invite
 
@@ -26,8 +27,9 @@ jobs:
   check-slack-invite:
     name: Check Slack Invite
     runs-on: ubuntu-latest
-    # Chromium + deps are baked in, so there's no slow browser download at
-    # runtime. Keep the `playwright@` install below on the same version tag.
+    # Browser OS deps are baked in. We install real Google Chrome below (the
+    # image only ships headless Chromium, which Slack now bot-blocks). Keep the
+    # `playwright@` install below on the same version tag as the image.
     container:
       image: mcr.microsoft.com/playwright:v1.49.1-jammy
     # A hung page-load should fail loudly, not sit there for the 6h default.
@@ -41,13 +43,17 @@ jobs:
         id: probe
         run: |
           # Install only the Playwright JS package (seconds — no browser bytes;
-          # the browser is already in the image at $PLAYWRIGHT_BROWSERS_PATH).
-          # Isolated temp dir keeps us off the repo's pnpm package.json/lockfile.
+          # OS deps are already in the image). Isolated temp dir keeps us off
+          # the repo's pnpm package.json/lockfile.
           mkdir -p "$RUNNER_TEMP/pw"
           cp .github/scripts/check-slack-invite.mjs "$RUNNER_TEMP/pw/probe.mjs"
           cd "$RUNNER_TEMP/pw"
           npm init -y >/dev/null 2>&1
           PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1 npm install playwright@1.49.1 >/dev/null
+          # Install real Google Chrome — the probe launches channel:"chrome" to
+          # get past Slack's bot wall (headless Chromium is served a 403). OS
+          # deps are baked into the image, so this is just the browser binary.
+          npx playwright install chrome >/dev/null
           # Don't let set -e abort on a failing probe — we still need to copy the
           # screenshots/reason back so the artifact + issue steps can use them.
           set +e


### PR DESCRIPTION
# Ticket(s) Closed

None

## What

Make the Slack invite monitor launch real Google Chrome instead of bundled headless Chromium so it can read the actual invite page.

## Why

The monitor [started failing](https://github.com/paradedb/website/actions/runs/28130823828) with `detector_broken`. Slack now gates its shared-invite pages behind bot detection: it `403`s any client whose User-Agent Client Hints brand isn't `"Google Chrome"` and serves a "We're very sorry, but your browser is not supported!" interstitial instead of the real valid/expired invite content.

Playwright's bundled Chromium reports `"HeadlessChrome"`/`"Chromium"` (verified via the `sec-ch-ua` header), so both the known-dead canary and the live invite rendered the unsupported-browser page. The canary read "alive", tripping the `detector_broken` guard. Reproduced locally; real Google Chrome (brand `"Google Chrome"`) sails through and gets a `200` with the genuine invite content.

## How

**`.github/scripts/check-slack-invite.mjs`**

- Launch with `chromium.launch({ channel: "chrome" })` (real Google Chrome) instead of bundled headless Chromium.
- Removed the custom `userAgent` override — Playwright derives the client-hint brand from a set UA, which reintroduces the non-`"Google Chrome"` brand and gets blocked again. The `locale: "en-US"` pin from #328 stays.
- Added an explicit `blocked` signal: if a page renders the `"your browser is not supported"` interstitial, return `blocked: true` rather than guessing dead/alive, and report a `detector_broken` status with an accurate cause (so a future block is diagnosed correctly instead of blaming `DEAD_PHRASES`).

**`.github/workflows/check-slack-invite.yml`**

- Added `npx playwright install chrome` to install real Google Chrome (the `mcr.microsoft.com/playwright` image only ships headless Chromium; OS deps are already baked in).
- Refreshed comments that referred to "headless browser" / "Chromium baked in".

## Tests

- Ran the updated probe locally against the live invite and the known-dead canary: canary → `DEAD (matched "no longer active")`, live → `alive`, final `STATUS: healthy`, exit 0.
- Confirmed the failure path: with headless Chromium the same script now reports `BLOCKED (unsupported-browser page)` → `detector_broken` with the corrected message, rather than a misleading `DEAD_PHRASES` complaint.
- `npx prettier --check` passes on both changed files.
