### PR TITLE
fix: dark-mode logo border doubling + benefit title font size

### DIFF
--- a/src/components/blog/TokenizerDemo.tsx
+++ b/src/components/blog/TokenizerDemo.tsx
@@ -4,11 +4,7 @@ import React, { useState, useMemo, useRef, useEffect } from "react";
 import { stemmer } from "porter-stemmer";
 
 type DemoMode =
-  | "character-filtering"
-  | "tokenization"
-  | "stemming"
-  | "stopwords"
-  | "display";
+  "character-filtering" | "tokenization" | "stemming" | "stopwords" | "display";
 type TokenizationMethod = "whitespace" | "trigram";
 
 interface TokenizerDemoProps {

--- a/src/components/mdx/Callout.tsx
+++ b/src/components/mdx/Callout.tsx
@@ -9,12 +9,7 @@ import {
 import { cx } from "@/lib/utils";
 
 export type CalloutVariant =
-  | "info"
-  | "note"
-  | "warning"
-  | "success"
-  | "danger"
-  | "tip";
+  "info" | "note" | "warning" | "success" | "danger" | "tip";
 
 export interface CalloutProps {
   variant: CalloutVariant;

--- a/src/components/ui/Architecture.tsx
+++ b/src/components/ui/Architecture.tsx
@@ -313,7 +313,7 @@ export default function Architecture() {
                           {benefit.icon}
                         </span>
                         <div>
-                          <div className="font-sans text-sm font-semibold text-indigo-950 dark:text-white">
+                          <div className="font-sans text-base font-semibold text-indigo-950 dark:text-white tracking-tight">
                             {benefit.title}
                           </div>
                           <div className="font-sans text-sm leading-relaxed text-slate-600 dark:text-slate-400 min-h-[2lh]">

--- a/src/components/ui/Hero.tsx
+++ b/src/components/ui/Hero.tsx
@@ -98,7 +98,6 @@ export default async function Hero() {
         <div className="mt-0 relative z-20 w-full">
           <div className="px-4 md:px-12 w-full mx-auto relative">
             <div className="absolute top-0 left-4 md:left-12 right-4 md:right-12 h-px bg-white/20 z-30" />
-            <div className="absolute bottom-0 left-4 md:left-12 right-4 md:right-12 h-px bg-white/20 z-30" />
             <div className="w-full">
               <LogoCloud variant="white" className="bg-transparent" />
             </div>


### PR DESCRIPTION
## Summary
Two small landing-page fixes that were most visible in dark mode:

1. **Double border below the hero logos** — the Hero's own `bottom-0` divider was stacking with the Architecture section's top hatch border (`border-y`) at the same inset, producing two ~1px lines. In light mode the indigo→white section change masked it; in dark mode both lines read as light against dark backgrounds. Removed the redundant Hero divider; the Architecture section's top border now serves as the single divider, and the Hero's vertical guide lines extend down to meet it cleanly.

2. **Undersized Architecture benefit titles** — "One search index" / "A full search engine in your database" titles were `text-sm`, smaller than the equivalent feature-card titles elsewhere. Bumped to `text-base` + `tracking-tight` to match the PostgresNative feature cards. Body copy was already `text-sm` (the standard small body size) and is unchanged.

## Changes
- `src/components/ui/Hero.tsx` — remove redundant `bottom-0` logo-band divider
- `src/components/ui/Architecture.tsx` — benefit titles `text-sm` → `text-base tracking-tight`

## Verification
Checked in the dark-mode dev preview: the boundary below the logos now renders a single border, and the benefit titles compute to 16px (matching the canonical feature-card title size) with body copy at 14px.

🤖 Generated with [Claude Code](https://claude.com/claude-code)