### PR TITLE
ci: run Prettier from the repo's pinned version instead of latest

### DIFF
--- a/.github/workflows/lint-markdown.yml
+++ b/.github/workflows/lint-markdown.yml
@@ -45,7 +45,9 @@ jobs:
         run: npm install -g markdownlint-cli
 
       - name: Run Markdown Lint
-        run: markdownlint "**/*.md"
+        # Ignore node_modules — pnpm now populates it, and markdownlint (unlike
+        # Prettier) does not skip it by default.
+        run: markdownlint "**/*.md" --ignore node_modules
 
       - name: Run Prettier
         run: pnpm exec prettier --check "{**/*.md,**/*.mdx}" --ignore-path .prettierignore

--- a/.github/workflows/lint-markdown.yml
+++ b/.github/workflows/lint-markdown.yml
@@ -28,14 +28,24 @@ jobs:
       - name: Checkout Git Repository
         uses: actions/checkout@v6
 
+      - name: Set up pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 9
+
       - name: Set up NodeJS Environment
         uses: actions/setup-node@v6
+        with:
+          cache: pnpm
 
-      - name: Install Prettier and markdownlint
-        run: npm install -g prettier markdownlint-cli
+      - name: Install Dependencies
+        run: pnpm install --frozen-lockfile --ignore-scripts
+
+      - name: Install markdownlint
+        run: npm install -g markdownlint-cli
 
       - name: Run Markdown Lint
         run: markdownlint "**/*.md"
 
       - name: Run Prettier
-        run: prettier --check "{**/*.md,**/*.mdx}" --ignore-path .prettierignore
+        run: pnpm exec prettier --check "{**/*.md,**/*.mdx}" --ignore-path .prettierignore

--- a/.github/workflows/lint-markdown.yml
+++ b/.github/workflows/lint-markdown.yml
@@ -45,8 +45,6 @@ jobs:
         run: npm install -g markdownlint-cli
 
       - name: Run Markdown Lint
-        # Ignore node_modules — pnpm now populates it, and markdownlint (unlike
-        # Prettier) does not skip it by default.
         run: markdownlint "**/*.md" --ignore node_modules
 
       - name: Run Prettier

--- a/.github/workflows/lint-typescript.yml
+++ b/.github/workflows/lint-typescript.yml
@@ -28,11 +28,18 @@ jobs:
       - name: Checkout Git Repository
         uses: actions/checkout@v6
 
+      - name: Set up pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 9
+
       - name: Set up NodeJS Environment
         uses: actions/setup-node@v6
+        with:
+          cache: pnpm
 
-      - name: Install Prettier
-        run: npm install -g prettier
+      - name: Install Dependencies
+        run: pnpm install --frozen-lockfile --ignore-scripts
 
       - name: Check Formatting on TypeScript Files
-        run: prettier --check "src/**/*.{ts,tsx}" --ignore-path .prettierignore
+        run: pnpm exec prettier --check "src/**/*.{ts,tsx}" --ignore-path .prettierignore

--- a/.github/workflows/lint-yaml.yml
+++ b/.github/workflows/lint-yaml.yml
@@ -28,11 +28,18 @@ jobs:
       - name: Checkout Git Repository
         uses: actions/checkout@v6
 
+      - name: Set up pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 9
+
       - name: Set up NodeJS Environment
         uses: actions/setup-node@v6
+        with:
+          cache: pnpm
 
-      - name: Install Prettier
-        run: npm install -g prettier
+      - name: Install Dependencies
+        run: pnpm install --frozen-lockfile --ignore-scripts
 
       - name: Check YAML Formatting
-        run: prettier --check "**/*.{yml,yaml}" --ignore-path .prettierignore
+        run: pnpm exec prettier --check "**/*.{yml,yaml}" --ignore-path .prettierignore


### PR DESCRIPTION
# Ticket(s) Closed

None

## What

Lint workflows now run Prettier from the repo's pinned `devDependency` instead of installing the latest release globally.

## Why

The three Prettier-based lint jobs ran `npm install -g prettier`, which always pulls the **latest** release. `package.json` pins `prettier@^3.8.3`, so CI (currently `3.9.4`) drifted ahead of contributors' local versions. Files formatted cleanly on `3.8.3` were reported as unformatted by CI's `3.9.4` — a failure no contributor could reproduce locally. See #338, where four unrelated files failed on this drift.

## How

**`lint-typescript.yml`, `lint-yaml.yml`, `lint-markdown.yml`**

- Add `pnpm/action-setup@v4` (`version: 9`) and enable `cache: pnpm` on `setup-node`.
- Replace `npm install -g prettier` with `pnpm install --frozen-lockfile --ignore-scripts`, so Prettier resolves from the lockfile.
  - `--ignore-scripts`: lint jobs don't need native builds (`sharp`); skipping them avoids `ERR_PNPM_IGNORED_BUILDS` and is faster.
- Run `pnpm exec prettier` instead of the global `prettier`.
- `lint-markdown.yml` keeps `markdownlint-cli` as a global install (not a repo dependency).

CI and local now use the same Prettier version by construction; bumping the version happens in one place (`package.json`).

## Tests

- `pnpm exec prettier --check` on the three edited workflows and the full `**/*.{yml,yaml}` glob passes locally on `3.8.3`.
- `pnpm install --frozen-lockfile --ignore-scripts` exits `0`.
- Editing these three workflow files re-triggers their own `paths` filters, so this PR's CI exercises the new steps end-to-end.
