### PR TITLE
ci: pin pnpm via packageManager field so CI matches local

### DIFF
--- a/.github/workflows/lint-markdown.yml
+++ b/.github/workflows/lint-markdown.yml
@@ -29,7 +29,7 @@ jobs:
         uses: actions/checkout@v7
 
       - name: Set up pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v6
 
       - name: Set up NodeJS Environment
         uses: actions/setup-node@v6

--- a/.github/workflows/lint-markdown.yml
+++ b/.github/workflows/lint-markdown.yml
@@ -30,8 +30,6 @@ jobs:
 
       - name: Set up pnpm
         uses: pnpm/action-setup@v4
-        with:
-          version: 9
 
       - name: Set up NodeJS Environment
         uses: actions/setup-node@v6

--- a/.github/workflows/lint-typescript.yml
+++ b/.github/workflows/lint-typescript.yml
@@ -29,7 +29,7 @@ jobs:
         uses: actions/checkout@v7
 
       - name: Set up pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v6
 
       - name: Set up NodeJS Environment
         uses: actions/setup-node@v6

--- a/.github/workflows/lint-typescript.yml
+++ b/.github/workflows/lint-typescript.yml
@@ -30,8 +30,6 @@ jobs:
 
       - name: Set up pnpm
         uses: pnpm/action-setup@v4
-        with:
-          version: 9
 
       - name: Set up NodeJS Environment
         uses: actions/setup-node@v6

--- a/.github/workflows/lint-yaml.yml
+++ b/.github/workflows/lint-yaml.yml
@@ -29,7 +29,7 @@ jobs:
         uses: actions/checkout@v7
 
       - name: Set up pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v6
 
       - name: Set up NodeJS Environment
         uses: actions/setup-node@v6

--- a/.github/workflows/lint-yaml.yml
+++ b/.github/workflows/lint-yaml.yml
@@ -30,8 +30,6 @@ jobs:
 
       - name: Set up pnpm
         uses: pnpm/action-setup@v4
-        with:
-          version: 9
 
       - name: Set up NodeJS Environment
         uses: actions/setup-node@v6

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "paradedb-website",
   "version": "0.2.0",
   "private": true,
+  "packageManager": "pnpm@11.10.0",
   "license": "Apache-2.0",
   "description": "ParadeDB marketing website",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -2,18 +2,17 @@
   "name": "paradedb-website",
   "version": "0.2.0",
   "private": true,
-  "packageManager": "pnpm@11.10.0",
-  "license": "Apache-2.0",
   "description": "ParadeDB marketing website",
   "repository": {
     "type": "git",
     "url": "https://github.com/paradedb/website.git"
   },
+  "license": "Apache-2.0",
   "scripts": {
-    "dev": "node scripts/generate-content-index.js && next dev --webpack",
     "build": "node scripts/generate-content-index.js && next build --webpack && next-sitemap && node scripts/generate-llms-txt.js && node scripts/generate-markdown.js",
-    "start": "next start",
-    "lint": "eslint ."
+    "dev": "node scripts/generate-content-index.js && next dev --webpack",
+    "lint": "eslint .",
+    "start": "next start"
   },
   "dependencies": {
     "@headlessui/react": "^2.2.10",
@@ -76,5 +75,6 @@
     "shiki": "^4.0.2",
     "tailwindcss": "^4.2.4",
     "typescript": "^6.0.3"
-  }
+  },
+  "packageManager": "pnpm@11.10.0"
 }


### PR DESCRIPTION
# Ticket(s) Closed

None

## What

Pin pnpm to `11.10.0` via the `packageManager` field so CI and local use the same pnpm, and bump `pnpm/action-setup` `v4` → `v6`.

## Why

The lint workflows pinned `pnpm/action-setup` to `version: 9`, while local development uses pnpm `11.10.0`. That's the same class of CI-vs-local drift we just removed for Prettier (#341/#342), one level up: a different pnpm major could resolve the lockfile differently. Declaring the version once, in `package.json`, makes it the single source of truth for both. While touching these steps, `pnpm/action-setup` was also two majors behind (`v4`; latest is `v6`).

## How

**`package.json`**

- Add `"packageManager": "pnpm@11.10.0"` (matches the current local and latest release).

**`lint-typescript.yml`, `lint-yaml.yml`, `lint-markdown.yml`**

- Drop the hardcoded `version: 9` from `pnpm/action-setup`; with no `version` input the action reads the `packageManager` field, so the pnpm version now lives in exactly one place.
- Bump `pnpm/action-setup@v4` → `@v6`.

## Tests

- `pnpm install --frozen-lockfile --ignore-scripts` passes on `11.10.0` — lockfile (`lockfileVersion 9.0`) is unchanged and compatible.
- `prettier --check` on the three edited workflows and `package.json` passes.
- Editing these workflow files re-triggers their own `paths` filters, so CI exercises the new pnpm setup end-to-end.
