### PR TITLE
chore: Recolor section background shading from indigo to slate

### DIFF
--- a/src/components/ui/AgentReady.tsx
+++ b/src/components/ui/AgentReady.tsx
@@ -315,7 +315,7 @@ export default function AgentReady() {
           <div className="absolute inset-y-0 right-4 md:right-12 w-px bg-slate-200 dark:bg-slate-900 z-30 pointer-events-none" />
 
           <div className="px-4 md:px-12 w-full flex flex-col relative isolate">
-            <div className="absolute inset-y-0 left-4 md:left-12 right-4 md:right-12 bg-indigo-50/60 dark:bg-indigo-950/20 -z-10" />
+            <div className="absolute inset-y-0 left-4 md:left-12 right-4 md:right-12 bg-slate-100/60 dark:bg-slate-900/40 -z-10" />
             <div className="absolute inset-y-0 left-1/2 -ml-[564px] w-px bg-slate-200 dark:bg-slate-900 z-30 pointer-events-none hidden xl:block" />
             <div className="absolute inset-y-0 left-1/2 ml-[564px] w-px bg-slate-200 dark:bg-slate-900 z-30 pointer-events-none hidden xl:block" />
 

--- a/src/components/ui/Architecture.tsx
+++ b/src/components/ui/Architecture.tsx
@@ -180,7 +180,7 @@ export default function Architecture() {
         {/* Top hatched border */}
         <div className="h-8 md:h-12 w-full bg-diagonal-hatch border-y border-slate-200 dark:border-slate-900 relative z-20 bg-slate-50/50 dark:bg-slate-900/50 opacity-60" />
 
-        <section className="relative py-10 md:py-14 border-r border-l border-slate-200 dark:border-slate-900 bg-indigo-50/40 dark:bg-indigo-950/20">
+        <section className="relative py-10 md:py-14 border-r border-l border-slate-200 dark:border-slate-900 bg-slate-100/60 dark:bg-slate-900/40">
           {/* Inner grid lines */}
           <div className="absolute inset-y-0 left-1/2 -ml-[564px] w-px bg-slate-200 dark:bg-slate-900 z-30 pointer-events-none hidden xl:block" />
           <div className="absolute inset-y-0 left-1/2 ml-[564px] w-px bg-slate-200 dark:bg-slate-900 z-30 pointer-events-none hidden xl:block" />

--- a/src/components/ui/Pricing.tsx
+++ b/src/components/ui/Pricing.tsx
@@ -78,7 +78,7 @@ export default function Pricing() {
 
         <div className="px-4 md:px-12 w-full flex flex-col relative isolate">
           {/* Background color layer */}
-          <div className="absolute inset-y-0 left-4 md:left-12 right-4 md:right-12 bg-indigo-50/60 dark:bg-indigo-950/20 z-0" />
+          <div className="absolute inset-y-0 left-4 md:left-12 right-4 md:right-12 bg-slate-100/60 dark:bg-slate-900/40 z-0" />
 
           {/* Inner Vertical Borders for boxed look */}
           <div className="absolute inset-y-0 left-1/2 -ml-[564px] w-px bg-slate-200 dark:bg-slate-900 z-30 pointer-events-none hidden xl:block" />

--- a/src/components/ui/SocialProof.tsx
+++ b/src/components/ui/SocialProof.tsx
@@ -58,7 +58,7 @@ export default function SocialProof() {
 
         <div className="px-4 md:px-12 w-full flex flex-col relative isolate">
           {/* Background color layer */}
-          <div className="absolute inset-y-0 left-4 md:left-12 right-4 md:right-12 bg-indigo-50/60 dark:bg-indigo-950/20 z-0" />
+          <div className="absolute inset-y-0 left-4 md:left-12 right-4 md:right-12 bg-slate-100/60 dark:bg-slate-900/40 z-0" />
 
           {/* Inner Vertical Borders for boxed look */}
           <div className="absolute inset-y-0 left-1/2 -ml-[564px] w-px bg-slate-200 dark:bg-slate-900 z-30 pointer-events-none hidden xl:block" />


### PR DESCRIPTION
Switches the homepage's section background shading from the indigo palette to a neutral slate/gray one, for a more subtle, less saturated look.

Each shaded section's tint changes from `bg-indigo-50/40–60 dark:bg-indigo-950/20` to a consistent `bg-slate-100/60 dark:bg-slate-900/40`:

- **Architecture** — "One database, two workloads"
- **SocialProof** — "Trusted by enterprises"
- **AgentReady** — agent integrations
- **Pricing** — "Ready, set, deploy"

Only the large section background tints are affected. Intentional indigo accents (active nav/TOC items, feature-icon chips, buttons, badges, highlighted nodes) are left unchanged.

Verified in the browser preview: all four sections render the same neutral slate shade in light and dark mode.