### PR TITLE
docs: Disclose HubSpot in the privacy policy

### DIFF
--- a/src/app/legal/privacy/index.mdx
+++ b/src/app/legal/privacy/index.mdx
@@ -2,9 +2,9 @@
 
 **ParadeDB Privacy Policy**
 
-**Version 1.6**
+**Version 1.7**
 
-**Last revised on: March 5, 2026**
+**Last revised on: July 10, 2026**
 
 The website located at [paradedb.com](https://www.paradedb.com/) (the "**Site**") is a copyrighted work belonging to ParadeDB, Inc. ("**Company**", "**us**", "**our**", and "**we**"). ParadeDB, Inc. is committed to maintaining robust privacy protections for its users. Our Privacy Policy ("Privacy Policy") is designed to help you understand how we collect, use and safeguard the information you provide to us and to assist you in making informed decisions when using our Service.
 
@@ -33,6 +33,8 @@ The Company may use both persistent and session cookies; persistent cookies rema
 ### 1.2 Analytics and Third-Party Tools
 
 We use Google Tag Manager ("GTM") and related analytics services to help us understand how visitors use the Site. These tools may collect information such as how often users visit the Site, what pages they visit, and what other sites they used prior to coming to the Site. We use the information we get from these tools to improve the Site and the Service. GTM is loaded when you access the Site, and we use Google Consent Mode to control analytics cookie storage based on your location and cookie consent choices. For visitors in the European Economic Area, the United Kingdom, Iceland, Liechtenstein, and Norway, analytics cookie storage is denied by default unless you accept analytics cookies through our cookie banner. For visitors in other regions, analytics cookie storage is granted by default and can be disabled by declining analytics cookies through the banner. Declining analytics cookies limits browser-based tracking to anonymous, cookieless data. When analytics cookie storage is denied, Google may still receive limited anonymous, cookieless signals. Google's ability to use and share information collected by Google Analytics about your visits to the Site is restricted by the [Google Analytics Terms of Service](https://marketingplatform.google.com/about/analytics/terms/us/) and the [Google Privacy Policy](https://policies.google.com/privacy).
+
+We also use HubSpot, a customer relationship management and marketing platform, to understand how visitors interact with the Site and to manage our communications with you. HubSpot may set cookies and collect information such as pages viewed, links clicked, and, where you provide it, information that identifies you as a contact. HubSpot is loaded through GTM and is gated by the same analytics cookie consent described above: it is denied by default for visitors in the European Economic Area, the United Kingdom, Iceland, Liechtenstein, and Norway unless you accept analytics cookies through our cookie banner, and it can be disabled in other regions by declining analytics cookies through the banner. For more information, see the [HubSpot Privacy Policy](https://legal.hubspot.com/privacy-policy).
 
 ### 1.3 Information You Provide Directly
 
@@ -66,7 +68,7 @@ In the event we undergo a business transaction such as a merger, acquisition by 
 
 Depending on the context, we may disclose personal information to:
 
-- Service providers and vendors that help us operate, secure, and improve the Site and Service (for example, hosting, analytics, and communication providers).
+- Service providers and vendors that help us operate, secure, and improve the Site and Service (for example, hosting, analytics, customer relationship management, and communication providers).
 - Professional advisors (such as legal, accounting, or auditing advisors).
 - Government authorities, law enforcement, or other parties where disclosure is required by law or needed to protect rights, safety, and security.
 - Counterparties involved in actual or proposed mergers, acquisitions, financing, or asset sales.


### PR DESCRIPTION
# Ticket(s) Closed

None

## What

Name HubSpot in the privacy policy so all third-party tools we run are disclosed.

## Why

The policy thoroughly disclosed Google Analytics / GTM / Consent Mode but never named HubSpot, which sets cookies and can tie activity to an identified contact. Tracker gating itself was handled in GTM (HubSpot gated on `analytics_storage`; RB2B/Apollo/Ahrefs removed), so no website code change is needed — only this disclosure.

## How

**`src/app/legal/privacy/index.mdx`**

- §1.2 Analytics and Third-Party Tools: add a HubSpot paragraph — what it collects, that it loads via GTM and is gated by the same analytics cookie consent (denied by default in the EEA/UK/Iceland/Liechtenstein/Norway, opt-out elsewhere), with a link to HubSpot's privacy policy.
- §2.3 Categories of Recipients: add `customer relationship management` to the example provider list.
- Bump to **Version 1.7**, last revised **July 10, 2026**.

## Tests

- `pnpm run build` passes (MDX compiles).
- Prettier clean; `MD013` (line length) disabled per `.markdownlint.yaml`.

https://claude.ai/code/session_01CCqKG8tvLmyQZkYXPaFgdx