### PR TITLE
feat: link splash and footer CTA to cloud early access

### DIFF
--- a/src/components/ui/CloudWaitlist.tsx
+++ b/src/components/ui/CloudWaitlist.tsx
@@ -22,7 +22,8 @@ const EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
 // Waitlister only stores fields as subscriber custom fields when they're
 // nested inside `metadata`, not when sent top-level.
 function attribution() {
-  if (typeof window === "undefined") return { referred_by: undefined, meta: {} };
+  if (typeof window === "undefined")
+    return { referred_by: undefined, meta: {} };
   const params = new URLSearchParams(window.location.search);
   return {
     referred_by: params.get("ref") ?? undefined,

--- a/src/components/ui/Hero.tsx
+++ b/src/components/ui/Hero.tsx
@@ -1,5 +1,6 @@
 import { ArrowAnimated } from "@/components/ui/ArrowAnimated";
 import { documentation } from "@/lib/links";
+import { siteConfig } from "@/app/siteConfig";
 import Link from "next/link";
 import { Button } from "../Button";
 import LogoCloud from "./LogoCloud";
@@ -61,11 +62,10 @@ export default async function Hero() {
                   className="text-md hover:group hover:bg-white/10 bg-transparent border-none h-10 px-4 hover:bg-transparent dark:hover:bg-transparent w-full sm:w-auto"
                 >
                   <Link
-                    href={documentation.BASE}
+                    href={siteConfig.baseLinks.cloud}
                     className="text-white flex items-center justify-center gap-2 w-full"
-                    target="_blank"
                   >
-                    Documentation
+                    Cloud Early Access
                     <ArrowAnimated
                       className="stroke-white"
                       aria-hidden="true"

--- a/src/components/ui/PreFooterCta.tsx
+++ b/src/components/ui/PreFooterCta.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { documentation } from "@/lib/links";
+import { siteConfig } from "@/app/siteConfig";
 import Link from "next/link";
 import { Button } from "../Button";
 import { ArrowAnimated } from "@/components/ui/ArrowAnimated";
@@ -60,14 +60,13 @@ export default function PreFooterCta() {
                 <Button
                   asChild
                   variant="ghost"
-                  className="text-md hover:group hover:bg-white/10 bg-transparent border-0 h-10 px-4 dark:hover:bg-transparent"
+                  className="text-md hover:group bg-transparent border-0 h-10 px-4 hover:bg-transparent dark:hover:bg-transparent"
                 >
                   <Link
-                    href={documentation.BASE}
+                    href={siteConfig.baseLinks.cloud}
                     className="text-white flex items-center gap-2"
-                    target="_blank"
                   >
-                    Documentation
+                    Cloud Early Access
                     <ArrowAnimated
                       className="stroke-white"
                       aria-hidden="true"


### PR DESCRIPTION
## Summary
- Replace the "Documentation" secondary button in the hero splash and the pre-footer CTA with a **Cloud Early Access** button linking to the internal `/cloud` waitlist page (`siteConfig.baseLinks.cloud`).
- Drop `target="_blank"` since these now point to an internal route.
- Remove the leftover `hover:bg-white/10` background on the pre-footer CTA button so its hover state matches the hero button (transparent in light and dark).

## Testing
- Verified in the dev server: both buttons render as "Cloud Early Access" and resolve to `/cloud`; hover shows no background.

🤖 Generated with [Claude Code](https://claude.com/claude-code)