### PR TITLE
feat: Add managed cloud early access link to install script

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -135,6 +135,9 @@ echo ""
 printf "  %sIf you find ParadeDB useful, a star on GitHub means the world to us:%s\n" "$BOLD" "$RESET"
 printf "  %shttps://github.com/paradedb/paradedb%s\n" "$CYAN" "$RESET"
 echo ""
+printf "  %sWe're building a managed cloud. Request early access:%s\n" "$BOLD" "$RESET"
+printf "  %shttps://paradedb.com/cloud%s\n" "$CYAN" "$RESET"
+echo ""
 
 if [ "$SILENT" = false ]; then
   printf "  Continue? [Y/n] "


### PR DESCRIPTION
## Summary
Adds a line to the terminal install script output pointing users to the managed cloud early access page, shown right below the existing GitHub star message.

The new lines match the existing style (bold label + cyan URL) and link to `https://paradedb.com/cloud` — the same early-access page linked from the splash hero and footer CTA (`baseLinks.cloud`).

## Output preview
```
If you find ParadeDB useful, a star on GitHub means the world to us:
https://github.com/paradedb/paradedb

We're building a managed cloud. Request early access:
https://paradedb.com/cloud
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)