### PR TITLE
feat: match toolkit section code colors to Benchmark section

### DIFF
--- a/src/app/cloud/page.tsx
+++ b/src/app/cloud/page.tsx
@@ -27,7 +27,8 @@ export default function CloudPage() {
       </h1>
       <p className="mt-4 max-w-2xl text-base text-indigo-50 sm:text-lg">
         We&apos;re building a fully managed ParadeDB: one Postgres for your
-        application data, full-text search, vector retrieval, and aggregations. Waitlist open now.
+        application data, full-text search, vector retrieval, and aggregations.
+        Waitlist open now.
       </p>
 
       <div className="mt-8 w-full">

--- a/src/components/Code.tsx
+++ b/src/components/Code.tsx
@@ -1,12 +1,19 @@
 import { cx } from "@/lib/utils";
-import type { BundledLanguage, BundledTheme } from "shiki";
+import type {
+  BundledLanguage,
+  BundledTheme,
+  ThemeRegistrationAny,
+} from "shiki";
 import { codeToHtml } from "shiki";
 import CopyToClipboard from "./CopyToClipboard";
+
+type Theme = BundledTheme | ThemeRegistrationAny;
 
 type Props = {
   code: string;
   lang?: BundledLanguage;
-  theme?: BundledTheme;
+  themeLight?: Theme;
+  themeDark?: Theme;
   filename?: string;
   className?: string;
   copy?: boolean;
@@ -15,17 +22,19 @@ type Props = {
 export default async function Code({
   code,
   lang = "typescript",
+  themeLight = "github-light",
+  themeDark = "github-dark",
   className,
   copy = true,
 }: Props) {
   const htmlLight = await codeToHtml(code, {
     lang,
-    theme: "github-light",
+    theme: themeLight,
   });
 
   const htmlDark = await codeToHtml(code, {
     lang,
-    theme: "github-dark",
+    theme: themeDark,
   });
 
   return (

--- a/src/components/ui/SearchFeatures.tsx
+++ b/src/components/ui/SearchFeatures.tsx
@@ -1,5 +1,6 @@
 import Code from "../Code";
 import SearchFeaturesClient from "./SearchFeaturesClient";
+import { paradedbSqlLight, paradedbSqlDark } from "./paradedbSqlTheme";
 import {
   RiSearchEyeLine,
   RiTranslate2,
@@ -70,6 +71,8 @@ export default async function SearchFeatures() {
         <Code
           code={indexingCode}
           lang="sql"
+          themeLight={paradedbSqlLight}
+          themeDark={paradedbSqlDark}
           className="[&_pre]:!bg-transparent"
           copy={false}
         />
@@ -97,6 +100,8 @@ export default async function SearchFeatures() {
         <Code
           code={fullTextCode}
           lang="sql"
+          themeLight={paradedbSqlLight}
+          themeDark={paradedbSqlDark}
           className="[&_pre]:!bg-transparent"
           copy={false}
         />
@@ -124,6 +129,8 @@ export default async function SearchFeatures() {
         <Code
           code={vectorCode}
           lang="sql"
+          themeLight={paradedbSqlLight}
+          themeDark={paradedbSqlDark}
           className="[&_pre]:!bg-transparent"
           copy={false}
         />
@@ -151,6 +158,8 @@ export default async function SearchFeatures() {
         <Code
           code={filteringCode}
           lang="sql"
+          themeLight={paradedbSqlLight}
+          themeDark={paradedbSqlDark}
           className="[&_pre]:!bg-transparent"
           copy={false}
         />
@@ -178,6 +187,8 @@ export default async function SearchFeatures() {
         <Code
           code={aggregationsCode}
           lang="sql"
+          themeLight={paradedbSqlLight}
+          themeDark={paradedbSqlDark}
           className="[&_pre]:!bg-transparent"
           copy={false}
         />

--- a/src/components/ui/paradedbSqlTheme.ts
+++ b/src/components/ui/paradedbSqlTheme.ts
@@ -30,7 +30,10 @@ const scopes = (c: {
     scope: ["punctuation", "meta.brace", "keyword.operator.symbol"],
     settings: { foreground: c.muted },
   },
-  { scope: ["comment", "punctuation.definition.comment"], settings: { foreground: c.muted } },
+  {
+    scope: ["comment", "punctuation.definition.comment"],
+    settings: { foreground: c.muted },
+  },
 ];
 
 export const paradedbSqlLight: ThemeRegistrationAny = {

--- a/src/components/ui/paradedbSqlTheme.ts
+++ b/src/components/ui/paradedbSqlTheme.ts
@@ -1,0 +1,62 @@
+import type { ThemeRegistrationAny } from "shiki";
+
+// SQL syntax-highlight palette shared with the Benchmark section
+// (see BenchmarkPanel.tsx). Keyword=indigo, string=emerald, function=sky,
+// number=amber, punctuation/comment=slate.
+const scopes = (c: {
+  keyword: string;
+  string: string;
+  fn: string;
+  number: string;
+  muted: string;
+}) => [
+  {
+    scope: ["keyword", "keyword.operator", "storage", "storage.type"],
+    settings: { foreground: c.keyword },
+  },
+  {
+    scope: ["string", "string.quoted", "constant.other.string"],
+    settings: { foreground: c.string },
+  },
+  {
+    scope: ["entity.name.function", "support.function", "meta.function-call"],
+    settings: { foreground: c.fn },
+  },
+  {
+    scope: ["constant.numeric", "constant.language", "constant"],
+    settings: { foreground: c.number },
+  },
+  {
+    scope: ["punctuation", "meta.brace", "keyword.operator.symbol"],
+    settings: { foreground: c.muted },
+  },
+  { scope: ["comment", "punctuation.definition.comment"], settings: { foreground: c.muted } },
+];
+
+export const paradedbSqlLight: ThemeRegistrationAny = {
+  name: "paradedb-sql-light",
+  type: "light",
+  fg: "#334155", // slate-700
+  bg: "#00000000",
+  settings: scopes({
+    keyword: "#4f46e5", // indigo-600
+    string: "#059669", // emerald-600
+    fn: "#0284c7", // sky-600
+    number: "#d97706", // amber-600
+    muted: "#94a3b8", // slate-400
+  }),
+};
+
+export const paradedbSqlDark: ThemeRegistrationAny = {
+  name: "paradedb-sql-dark",
+  type: "dark",
+  fg: "#cbd5e1", // slate-300
+  bg: "#00000000",
+  settings: scopes({
+    keyword: "#818cf8", // indigo-400
+    string: "#34d399", // emerald-400
+    fn: "#38bdf8", // sky-400
+    number: "#f59e0b", // amber-500
+    muted: "#64748b", // slate-500
+  }),
+};


### PR DESCRIPTION
## What

Render the SQL in the **"The complete toolkit for retrieval"** section with the same syntax-highlight palette used by the **"Elastic-quality performance."** (Benchmark) section, instead of Shiki's default GitHub light/dark themes.

## Why

The two sections sit close on the homepage but used different code palettes — the toolkit block used GitHub's red/purple/blue, while the Benchmark block uses a hand-rolled ParadeDB palette (indigo/emerald/sky/amber/slate). This unifies them.

## How

- Add `src/components/ui/paradedbSqlTheme.ts` — a Shiki light/dark theme pair mapping SQL scopes to the Benchmark colors (keyword→indigo, string→emerald, function→sky, number→amber, punctuation/comment→slate, base text→slate-700/300).
- Add optional `themeLight`/`themeDark` props to `Code`, defaulting to the existing `github-light`/`github-dark` so every other caller (e.g. the Hero) is unchanged.
- `SearchFeatures` passes the ParadeDB themes to its five code blocks.

## Verification

Ran the site locally and confirmed rendered token colors match the Benchmark section in both light and dark mode:

| Token | Toolkit (now) | Benchmark |
|---|---|---|
| keyword | `#4f46e5` / `#818cf8` | indigo-600 / indigo-400 |
| string | `#059669` / `#34d399` | emerald-600 / emerald-400 |
| base text | `#334155` / `#cbd5e1` | slate-700 / slate-300 |

`tsc --noEmit` passes clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)