### PR TITLE
fix: Add rel=nofollow to benchmark JSON download link

### DIFF
--- a/src/components/ui/BenchmarkPanel.tsx
+++ b/src/components/ui/BenchmarkPanel.tsx
@@ -150,6 +150,7 @@ function MeasurementNote() {
         <a
           href="/benchmarks/topk_10_hn_text.json"
           download
+          rel="nofollow"
           className="text-indigo-600 dark:text-indigo-400 underline underline-offset-2 hover:text-indigo-500"
         >
           Download raw result JSON


### PR DESCRIPTION
# Ticket(s) Closed

None

## What

Add `rel="nofollow"` to the raw benchmark JSON download link in the benchmark panel.

## Why

The Semrush Site Audit (Jul 13, 2026 crawl) flags a "2 resources are formatted as page link" notice on the homepage. The crawler sees `<a href="/benchmarks/topk_10_hn_text.json" download>` and treats the JSON file as a page to follow and index. The two reported rows are the same link — `paradedb.com` and `paradedb.com/` are the homepage crawled with and without the trailing slash.

The link itself is intentional and worth keeping: it lets readers download the raw benchmark results. `rel="nofollow"` tells crawlers the JSON is not a page meant for the index, clearing the notice without changing behavior for users.

## How

**`src/components/ui/BenchmarkPanel.tsx`**

- `MeasurementNote()`: added `rel="nofollow"` to the "Download raw result JSON" anchor. `href` and `download` are unchanged.

## Tests

- `pnpm run build` passes
- `pnpm exec prettier --check` passes on the changed file
- Verified the attribute reaches the server-rendered HTML that Semrush crawls: `.next/server/app/index.html` contains `<a href="/benchmarks/topk_10_hn_text.json" download="" rel="nofollow" ...>`
