### PR TITLE
chore: Update Docker pulls count to 2M

### DIFF
--- a/src/components/ui/CommunityProof.tsx
+++ b/src/components/ui/CommunityProof.tsx
@@ -39,7 +39,7 @@ export default function CommunityProof() {
                     <DockerLogo className="w-full h-full dark:brightness-0 dark:invert" />
                   </div>
                   <div className="text-2xl font-bold text-indigo-950 dark:text-white mb-2">
-                    1.5M+
+                    2M+
                   </div>
                   <div className="font-semibold text-slate-900 dark:text-slate-100 mb-2">
                     Docker deployments


### PR DESCRIPTION
# Ticket(s) Closed

None

## What

Updates the Docker deployments stat on the homepage community proof section from `1.5M+` to `2M+`.

## Why

The Docker Hub pull count has grown past 2 million, so the displayed figure was understating adoption.

## How

**`src/components/ui/CommunityProof.tsx`**

- Docker card stat: `1.5M+` → `2M+`

## Tests

- None run — static string change with no build or render implications

https://claude.ai/code/session_017mie7S69bSCa3SreQs9erR