### PR TITLE
chore: Use reusable Slack alert action for invite monitor

### DIFF
--- a/.github/workflows/check-slack-invite.yml
+++ b/.github/workflows/check-slack-invite.yml
@@ -72,25 +72,21 @@ jobs:
           if-no-files-found: ignore
           retention-days: 7
 
-      - name: Ping Slack on failure
+      - name: Build Slack failure payload
         # Fires for dead/detector_broken only; "inconclusive" exits 0 so it won't fire.
         if: always() && (steps.probe.outputs.status == 'dead' || steps.probe.outputs.status == 'detector_broken')
         env:
-          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_GITHUB_CHANNEL_WEBHOOK_URL }}
           # Via env (not inline ${{ }}) so quotes in the reason can't break the shell.
           MONITOR_STATUS: ${{ steps.probe.outputs.status }}
           MONITOR_REASON: ${{ steps.probe.outputs.reason }}
           REPO: ${{ github.repository }}
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         run: |
-          if [ -z "$SLACK_WEBHOOK_URL" ]; then
-            echo "SLACK_GITHUB_CHANNEL_WEBHOOK_URL not set — skipping Slack ping."
-            exit 0
-          fi
           # node (already in the image) builds the JSON so quotes in the reason
           # are escaped — no jq dependency needed.
-          payload="$(node -e 'process.stdout.write(JSON.stringify({
-            text: "🚨 ParadeDB Community Slack invite needs attention - <!here>",
+          node > slack-payload.json <<'NODE'
+          process.stdout.write(JSON.stringify({
+            text: "🚨 ParadeDB Community Slack invite needs attention - <!subteam^S0BLL9VCQ4A|@cloud-maintainers>",
             attachments: [{
               color: "danger",
               fields: [
@@ -100,5 +96,12 @@ jobs:
                 { title: "View Logs", value: `<${process.env.RUN_URL}|Click here>`, short: false }
               ]
             }]
-          }))')"
-          curl -fsS -X POST -H 'Content-type: application/json' --data "$payload" "$SLACK_WEBHOOK_URL"
+          }))
+          NODE
+
+      - name: Ping Slack on failure
+        if: always() && (steps.probe.outputs.status == 'dead' || steps.probe.outputs.status == 'detector_broken')
+        uses: paradedb/actions/slack-alert@v10
+        with:
+          webhook_url: ${{ secrets.SLACK_GITHUB_CHANNEL_WEBHOOK_URL }}
+          payload_file: slack-payload.json


### PR DESCRIPTION
## What changed

- Replaced the Slack invite monitor's inline webhook post with `paradedb/actions/slack-alert@v10`.
- Changed the alert mention from `<!here>` to `@cloud-maintainers`.
- Kept the custom Slack attachment fields for status, details, repository, and logs.

## Validation

- `git diff --check`
- Ruby YAML parse for the touched workflow
- `npx --yes prettier --check` for the touched workflow
