### PR TITLE
fix: Point install command at bash, and repair ?tag=

### DIFF
--- a/src/app/api/install/route.ts
+++ b/src/app/api/install/route.ts
@@ -10,9 +10,12 @@ export async function GET(request: Request) {
   const source = url.searchParams.get("source") ?? "direct";
 
   let script = readFileSync(scriptPath, "utf-8");
+  // Matches the whole `IMAGE=` assignment so the substitution survives edits to
+  // the script (e.g. the `${PDB_IMAGE:-...}` default). Uses a replacer function
+  // so `$` in the replacement is not treated as a capture reference.
   script = script.replace(
-    'IMAGE="paradedb/paradedb:latest"',
-    `IMAGE="paradedb/paradedb:${tag}"`,
+    /^IMAGE=.*$/m,
+    () => `IMAGE="\${PDB_IMAGE:-paradedb/paradedb:${tag}}"`,
   );
 
   // Fire GA4 Measurement Protocol event (fire-and-forget)

--- a/src/components/ui/Hero.tsx
+++ b/src/components/ui/Hero.tsx
@@ -9,7 +9,7 @@ import { DarkModeOverlay } from "./DarkModeOverlay";
 import Code from "@/components/Code";
 import CopyToClipboard from "@/components/CopyToClipboard";
 
-const installCommand = `curl -fsSL https://paradedb.com/install.sh | sh`;
+const installCommand = `curl -fsSL https://paradedb.com/install.sh | bash`;
 
 export default async function Hero() {
   return (


### PR DESCRIPTION
# Ticket(s) Closed

None

## What

Fixes `curl -fsSL https://paradedb.com/install.sh | sh` failing on Debian/Ubuntu, and repairs the `?tag=` query parameter, which had silently become a no-op.

## Why

`scripts/install.sh` is a Bash script (`set -Eeuo pipefail`, `$'\033…'` ANSI escapes, `local`), but `Hero.tsx` told users to pipe it into `sh`. On Debian/Ubuntu `/bin/sh` is dash, which has no `pipefail`, so the install aborted on line 21 with a cryptic error before doing anything:

```
ubuntu@host:~$ curl -fsSL https://paradedb.com/install.sh | sh
sh: 21: set: Illegal option -o pipefail
```

Reported by an external user who hit it on every Ubuntu machine they tried.

Separately, `route.ts` rewrote the image tag by replacing the literal string `IMAGE="paradedb/paradedb:latest"`. That line became `IMAGE="${PDB_IMAGE:-paradedb/paradedb:latest}"` when the env-var overrides were added, so the substring stopped matching and `/install.sh?tag=<x>` has been serving `latest` regardless of the tag requested.

## How

**`src/components/ui/Hero.tsx`**

- Install command: `curl -fsSL https://paradedb.com/install.sh | sh` → `... | bash`

**`src/app/api/install/route.ts`**

- Tag substitution: literal-string match on `IMAGE="paradedb/paradedb:latest"` → regex match on the whole assignment, `/^IMAGE=.*$/m`.
- Replacement preserves the env-var override: `IMAGE="${PDB_IMAGE:-paradedb/paradedb:<tag>}"`.
- Uses a replacer function so the `$` in `${PDB_IMAGE…}` is not interpreted as a capture-group reference.

`scripts/install.sh` is deliberately untouched here. A follow-up PR makes the script body POSIX-compatible so `| sh` works again on its own, which is a better fix than a bash-only guard for the stale `| sh` commands that live in blog posts and shell history.

## Tests

- `pnpm exec tsc --noEmit` passes
- `pnpm exec prettier --check` passes on the touched files
- Applied `route.ts`'s exact regex to `scripts/install.sh` in Node: `tag=0.20.0` yields `IMAGE="${PDB_IMAGE:-paradedb/paradedb:0.20.0}"`, and an absent/invalid tag yields `latest`
- `pnpm run build` could not be run locally: it fails identically on clean `main` with `loader … @next/mdx/mdx-js-loader.js … does not have serializable options`, a pre-existing failure unrelated to this PR. The Vercel preview build on this PR passes.
