### PR TITLE
chore: Format /vs page files with Prettier

### DIFF
--- a/src/app/vs/layout-client.tsx
+++ b/src/app/vs/layout-client.tsx
@@ -20,8 +20,7 @@ export default function VsLayoutClient({
     pathname.endsWith(`/${c.slug}`),
   );
   const canGoBackward = !isIndex && currentPageIdx > 0;
-  const canGoForward =
-    !isIndex && currentPageIdx < VS_COMPETITORS.length - 1;
+  const canGoForward = !isIndex && currentPageIdx < VS_COMPETITORS.length - 1;
   const nextHref = canGoForward
     ? `${VS_BASE}/${VS_COMPETITORS[currentPageIdx + 1].slug}`
     : undefined;

--- a/src/app/vs/postgresql/page.tsx
+++ b/src/app/vs/postgresql/page.tsx
@@ -69,8 +69,8 @@ const config: VsConfig = {
         us: (
           <>
             One index: a segmented inverted index (
-            <A href="/learn/tantivy/introduction">Tantivy</A>), columnar storage,
-            and a SPANN-style IVF vector index
+            <A href="/learn/tantivy/introduction">Tantivy</A>), columnar
+            storage, and a SPANN-style IVF vector index
           </>
         ),
         them: (
@@ -157,7 +157,8 @@ const config: VsConfig = {
           <>
             <A href="/learn/postgresql/what-is-pgvector">pgvector</A> and GIN as
             two separate index scans, then{" "}
-            <A href="/learn/search-concepts/reciprocal-rank-fusion">RRF</A>-fused
+            <A href="/learn/search-concepts/reciprocal-rank-fusion">RRF</A>
+            -fused
           </>
         ),
       },

--- a/src/components/vs/VsBenchSummary.tsx
+++ b/src/components/vs/VsBenchSummary.tsx
@@ -24,17 +24,94 @@ type Row = {
 };
 
 const ROWS: Row[] = [
-  { type: "Top K", detail: "1 term · top 10", workload: "topk", field: "title", limit: 10, terms: "one" },
-  { type: "Top K", detail: "1 term · top 10", workload: "topk", field: "text", limit: 10, terms: "one" },
-  { type: "Top K", detail: "10 terms · top 10", workload: "topk", field: "text", limit: 10, terms: "ten" },
-  { type: "Filtered", detail: "score > 10", workload: "filtered_range", field: "text", limit: 10, terms: "one" },
-  { type: "Filtered", detail: "type = 'story'", workload: "filtered_literal", field: "text", limit: 10, terms: "one" },
-  { type: "Count", detail: "—", workload: "count", field: "title", limit: null, terms: "one" },
-  { type: "Count", detail: "—", workload: "count", field: "text", limit: null, terms: "one" },
-  { type: "Faceting", detail: "terms", workload: "facet_terms", field: "text", limit: null, terms: "one" },
-  { type: "Faceting", detail: "histogram", workload: "facet_histogram", field: "text", limit: null, terms: "one" },
-  { type: "Highlighting", detail: "—", workload: "highlight", field: "title", limit: null, terms: "one" },
-  { type: "Highlighting", detail: "—", workload: "highlight", field: "text", limit: null, terms: "one" },
+  {
+    type: "Top K",
+    detail: "1 term · top 10",
+    workload: "topk",
+    field: "title",
+    limit: 10,
+    terms: "one",
+  },
+  {
+    type: "Top K",
+    detail: "1 term · top 10",
+    workload: "topk",
+    field: "text",
+    limit: 10,
+    terms: "one",
+  },
+  {
+    type: "Top K",
+    detail: "10 terms · top 10",
+    workload: "topk",
+    field: "text",
+    limit: 10,
+    terms: "ten",
+  },
+  {
+    type: "Filtered",
+    detail: "score > 10",
+    workload: "filtered_range",
+    field: "text",
+    limit: 10,
+    terms: "one",
+  },
+  {
+    type: "Filtered",
+    detail: "type = 'story'",
+    workload: "filtered_literal",
+    field: "text",
+    limit: 10,
+    terms: "one",
+  },
+  {
+    type: "Count",
+    detail: "—",
+    workload: "count",
+    field: "title",
+    limit: null,
+    terms: "one",
+  },
+  {
+    type: "Count",
+    detail: "—",
+    workload: "count",
+    field: "text",
+    limit: null,
+    terms: "one",
+  },
+  {
+    type: "Faceting",
+    detail: "terms",
+    workload: "facet_terms",
+    field: "text",
+    limit: null,
+    terms: "one",
+  },
+  {
+    type: "Faceting",
+    detail: "histogram",
+    workload: "facet_histogram",
+    field: "text",
+    limit: null,
+    terms: "one",
+  },
+  {
+    type: "Highlighting",
+    detail: "—",
+    workload: "highlight",
+    field: "title",
+    limit: null,
+    terms: "one",
+  },
+  {
+    type: "Highlighting",
+    detail: "—",
+    workload: "highlight",
+    field: "text",
+    limit: null,
+    terms: "one",
+  },
 ];
 
 const LOADS = [1, 4, 8];
@@ -90,13 +167,18 @@ export default function VsBenchSummary({ data }: { data: VsBenchData }) {
     LOADS.flatMap((load) => METRICS.map((m) => ({ r, load, m }))),
   );
 
-  const usClass = "text-right font-mono text-[13px] tabular-nums text-indigo-700 dark:text-indigo-300";
-  const themClass = "text-right font-mono text-[13px] tabular-nums text-slate-600 dark:text-slate-400";
+  const usClass =
+    "text-right font-mono text-[13px] tabular-nums text-indigo-700 dark:text-indigo-300";
+  const themClass =
+    "text-right font-mono text-[13px] tabular-nums text-slate-600 dark:text-slate-400";
 
   return (
     <details className="group border border-slate-200 dark:border-slate-800">
       <summary className="flex cursor-pointer list-none items-center gap-2 px-4 py-3 font-mono text-[11px] uppercase tracking-[0.15em] text-slate-500 hover:text-slate-800 dark:text-slate-400 dark:hover:text-slate-200">
-        <span className="inline-block transition-transform group-open:rotate-90" aria-hidden>
+        <span
+          className="inline-block transition-transform group-open:rotate-90"
+          aria-hidden
+        >
           ▸
         </span>
         Full results table · all workloads at every concurrency
@@ -105,8 +187,8 @@ export default function VsBenchSummary({ data }: { data: VsBenchData }) {
         <table className="w-full text-left text-sm">
           <caption className="border-b border-slate-200 px-4 py-3 text-left text-xs text-slate-500 dark:border-slate-800 dark:text-slate-400">
             One row per workload, concurrency, and metric. Latency is in
-            milliseconds; throughput is completed queries per second. All figures
-            come from the downloadable data.
+            milliseconds; throughput is completed queries per second. All
+            figures come from the downloadable data.
           </caption>
           <thead>
             <tr>
@@ -125,24 +207,43 @@ export default function VsBenchSummary({ data }: { data: VsBenchData }) {
               const t = cell(r, key, load);
               const dnf = !t || t.timedOut;
               const zebra =
-                i % 2 === 0 ? "bg-white dark:bg-slate-950" : "bg-slate-50/40 dark:bg-slate-900/30";
+                i % 2 === 0
+                  ? "bg-white dark:bg-slate-950"
+                  : "bg-slate-50/40 dark:bg-slate-900/30";
               return (
-                <tr key={`${r.type}-${r.field}-${r.detail}-${load}-${m.metric}`} className={zebra}>
-                  <td className={`${TD} font-medium text-slate-900 dark:text-white`}>{r.type}</td>
-                  <td className={`${TD} font-mono text-[13px] text-slate-700 dark:text-slate-300`}>
+                <tr
+                  key={`${r.type}-${r.field}-${r.detail}-${load}-${m.metric}`}
+                  className={zebra}
+                >
+                  <td
+                    className={`${TD} font-medium text-slate-900 dark:text-white`}
+                  >
+                    {r.type}
+                  </td>
+                  <td
+                    className={`${TD} font-mono text-[13px] text-slate-700 dark:text-slate-300`}
+                  >
                     {r.field}
                   </td>
-                  <td className={`${TD} font-mono text-[13px] text-slate-600 dark:text-slate-400`}>
+                  <td
+                    className={`${TD} font-mono text-[13px] text-slate-600 dark:text-slate-400`}
+                  >
                     {r.detail}
                   </td>
-                  <td className={`${TD} text-right font-mono text-[13px] tabular-nums text-slate-700 dark:text-slate-300`}>
+                  <td
+                    className={`${TD} text-right font-mono text-[13px] tabular-nums text-slate-700 dark:text-slate-300`}
+                  >
                     {load}
                   </td>
-                  <td className={`${TD} border-l font-mono text-[13px] text-slate-700 dark:text-slate-300`}>
+                  <td
+                    className={`${TD} border-l font-mono text-[13px] text-slate-700 dark:text-slate-300`}
+                  >
                     {m.metric}
                   </td>
                   <td className={`${TD} border-l ${usClass}`}>{m.fmt(u)}</td>
-                  <td className={`${TD} ${themClass}`}>{dnf ? m.dnf : m.fmt(t)}</td>
+                  <td className={`${TD} ${themClass}`}>
+                    {dnf ? m.dnf : m.fmt(t)}
+                  </td>
                 </tr>
               );
             })}

--- a/src/components/vs/VsBenchmarkPanel.tsx
+++ b/src/components/vs/VsBenchmarkPanel.tsx
@@ -70,7 +70,10 @@ const SQL_TOKEN =
 function sqlLine(line: string, key: number): ReactNode {
   if (/^\s*--/.test(line)) {
     return (
-      <div key={key} className="whitespace-pre-wrap break-words text-slate-400 dark:text-slate-500">
+      <div
+        key={key}
+        className="whitespace-pre-wrap break-words text-slate-400 dark:text-slate-500"
+      >
         {line}
       </div>
     );
@@ -174,7 +177,10 @@ function pdbLines(sel: Sel, example: string): string[] {
         ? ["  AND type = 'story'"]
         : [];
   if (sel.workload === "count") {
-    return ["SELECT count(*) FROM hn_items", `WHERE ${sel.field} ||| '${example}'`];
+    return [
+      "SELECT count(*) FROM hn_items",
+      `WHERE ${sel.field} ||| '${example}'`,
+    ];
   }
   if (sel.workload === "highlight") {
     return [
@@ -238,8 +244,7 @@ function ftsLines(sel: Sel, example: string): string[] {
     ];
   }
   if (sel.workload === "facet_terms" || sel.workload === "facet_histogram") {
-    const groupExpr =
-      sel.workload === "facet_terms" ? "type" : "(score/50)*50";
+    const groupExpr = sel.workload === "facet_terms" ? "type" : "(score/50)*50";
     const col = sel.workload === "facet_terms" ? "type" : "score";
     return [
       "WITH hits AS (",
@@ -286,7 +291,10 @@ function esLines(sel: Sel, example: string): string[] {
       "}",
     ];
   }
-  if (sel.workload === "filtered_range" || sel.workload === "filtered_literal") {
+  if (
+    sel.workload === "filtered_range" ||
+    sel.workload === "filtered_literal"
+  ) {
     const filter =
       sel.workload === "filtered_range"
         ? '{ "range": { "score": { "gt": 10 } } }'
@@ -411,7 +419,9 @@ function CdfChart({
   const drawStyle = (delayMs: number) => ({
     strokeDasharray: 1,
     strokeDashoffset: grown ? 0 : 1,
-    transition: grown ? `stroke-dashoffset 900ms ease-out ${delayMs}ms` : "none",
+    transition: grown
+      ? `stroke-dashoffset 900ms ease-out ${delayMs}ms`
+      : "none",
   });
 
   // Share one x-axis: the larger of the two p99s so both curves fit.
@@ -423,7 +433,10 @@ function CdfChart({
   const yOf = (p: number) => CM.top + CPH - (p / 100) * CPH;
   const path = (vals: number[]) =>
     vals
-      .map((lat, i) => `${i === 0 ? "M" : "L"}${xOf(lat).toFixed(1)},${yOf(pcts[i]).toFixed(1)}`)
+      .map(
+        (lat, i) =>
+          `${i === 0 ? "M" : "L"}${xOf(lat).toFixed(1)},${yOf(pcts[i]).toFixed(1)}`,
+      )
       .join(" ");
   const yTicks = [0, 25, 50, 75, 100];
 
@@ -627,7 +640,13 @@ function CompareBody({
     return `${r >= 10 ? Math.round(r) : Math.round(r * 10) / 10}×`;
   };
   const ratios = (usVal: number | null, themVal: number | null) => {
-    if (themDnf || usVal == null || themVal == null || usVal <= 0 || themVal <= 0)
+    if (
+      themDnf ||
+      usVal == null ||
+      themVal == null ||
+      usVal <= 0 ||
+      themVal <= 0
+    )
       return { us: "", them: "" };
     return usVal <= themVal
       ? { us: fmtRatio(themVal, usVal), them: "" }
@@ -650,15 +669,23 @@ function CompareBody({
         <div className="min-w-0 flex-1 p-4">
           <div className="mb-4 flex flex-wrap items-center justify-between gap-x-4 gap-y-2">
             <span className="whitespace-nowrap font-mono text-[10px] uppercase tracking-[0.12em] text-slate-500 sm:text-[11px] sm:tracking-[0.18em] dark:text-slate-400">
-              {view === "cdf" ? "% ≤ latency · left is faster" : "Latency · lower is better"}
+              {view === "cdf"
+                ? "% ≤ latency · left is faster"
+                : "Latency · lower is better"}
             </span>
             <div className="flex items-center gap-3 font-mono text-[10px] uppercase tracking-[0.12em] text-slate-500 sm:gap-4 sm:text-[11px] dark:text-slate-400">
               <span className="flex items-center gap-2">
-                <span className="inline-block size-3 rounded-full bg-indigo-500" aria-hidden />
+                <span
+                  className="inline-block size-3 rounded-full bg-indigo-500"
+                  aria-hidden
+                />
                 ParadeDB
               </span>
               <span className="flex items-center gap-2">
-                <span className="inline-block size-3 rounded-full bg-slate-300 dark:bg-slate-500" aria-hidden />
+                <span
+                  className="inline-block size-3 rounded-full bg-slate-300 dark:bg-slate-500"
+                  aria-hidden
+                />
                 {competitorName}
               </span>
             </div>
@@ -682,8 +709,20 @@ function CompareBody({
                       {row.label}
                     </div>
                     <div className="space-y-1.5">
-                      {bar(row.us, false, "bg-indigo-500", "text-indigo-600 dark:text-indigo-400", r.us)}
-                      {bar(row.them, themDnf, "bg-slate-300 dark:bg-slate-600", "text-slate-400 dark:text-slate-500", r.them)}
+                      {bar(
+                        row.us,
+                        false,
+                        "bg-indigo-500",
+                        "text-indigo-600 dark:text-indigo-400",
+                        r.us,
+                      )}
+                      {bar(
+                        row.them,
+                        themDnf,
+                        "bg-slate-300 dark:bg-slate-600",
+                        "text-slate-400 dark:text-slate-500",
+                        r.them,
+                      )}
                     </div>
                   </div>
                 );
@@ -695,11 +734,17 @@ function CompareBody({
               </div>
               <div className="flex flex-wrap items-center gap-x-6 gap-y-1 font-mono text-[11px] tabular-nums">
                 <span className="flex items-center gap-2 text-indigo-600 dark:text-indigo-400">
-                  <span className="inline-block size-3 rounded-full bg-indigo-500" aria-hidden />
+                  <span
+                    className="inline-block size-3 rounded-full bg-indigo-500"
+                    aria-hidden
+                  />
                   {us?.qps != null ? `${us.qps} QPS` : "n/a"}
                 </span>
                 <span className="flex items-center gap-2 text-slate-400 dark:text-slate-500">
-                  <span className="inline-block size-3 rounded-full bg-slate-300 dark:bg-slate-500" aria-hidden />
+                  <span
+                    className="inline-block size-3 rounded-full bg-slate-300 dark:bg-slate-500"
+                    aria-hidden
+                  />
                   {themDnf
                     ? "0 QPS"
                     : them?.qps != null
@@ -975,24 +1020,26 @@ function WorkloadCard({
           </span>
         </div>
         <div className="flex font-mono text-[10px] uppercase tracking-[0.15em]">
-          {(["latency", "distribution", "schema", "reproduce"] as const).map((v) => {
-            const on = view === v;
-            return (
-              <button
-                key={v}
-                type="button"
-                aria-pressed={on}
-                onClick={() => setView(v)}
-                className={`px-2.5 py-1 transition-colors ${
-                  on
-                    ? "text-indigo-600 underline underline-offset-4 dark:text-indigo-400"
-                    : "text-slate-400 hover:text-slate-700 dark:text-slate-500 dark:hover:text-slate-300"
-                }`}
-              >
-                {v}
-              </button>
-            );
-          })}
+          {(["latency", "distribution", "schema", "reproduce"] as const).map(
+            (v) => {
+              const on = view === v;
+              return (
+                <button
+                  key={v}
+                  type="button"
+                  aria-pressed={on}
+                  onClick={() => setView(v)}
+                  className={`px-2.5 py-1 transition-colors ${
+                    on
+                      ? "text-indigo-600 underline underline-offset-4 dark:text-indigo-400"
+                      : "text-slate-400 hover:text-slate-700 dark:text-slate-500 dark:hover:text-slate-300"
+                  }`}
+                >
+                  {v}
+                </button>
+              );
+            },
+          )}
         </div>
       </div>
 
@@ -1044,7 +1091,10 @@ function WorkloadCard({
                   label="Filter"
                   options={[
                     { value: "filtered_range" as const, label: "score > 10" },
-                    { value: "filtered_literal" as const, label: "type = 'story'" },
+                    {
+                      value: "filtered_literal" as const,
+                      label: "type = 'story'",
+                    },
                   ]}
                   value={variant}
                   onChange={setVariant}
@@ -1148,8 +1198,12 @@ export default function VsBenchmarkPanel({ data }: { data: VsBenchData }) {
     { title: "Top K search", kind: "topk" },
     { title: "Filtered search", kind: "filtered" },
     { title: "Count over search", kind: "count" },
-    ...(has("facet_terms") ? [{ title: "Faceting", kind: "facet" as const }] : []),
-    ...(has("highlight") ? [{ title: "Highlighting", kind: "highlight" as const }] : []),
+    ...(has("facet_terms")
+      ? [{ title: "Faceting", kind: "facet" as const }]
+      : []),
+    ...(has("highlight")
+      ? [{ title: "Highlighting", kind: "highlight" as const }]
+      : []),
   ];
 
   return (

--- a/src/components/vs/VsPage.tsx
+++ b/src/components/vs/VsPage.tsx
@@ -125,69 +125,69 @@ export default function VsPage({ config }: { config: VsConfig }) {
 
       {/* ============ Which fits when (two-column) ============ */}
       {config.fits && (
-      <section>
-        <div className="mb-8">
-          <Badge className="mb-4">Which fits when</Badge>
-          <h2 className="text-2xl md:text-3xl font-bold tracking-tight text-indigo-950 dark:text-white mb-3">
-            Pick by your workload.
-          </h2>
-          <p className="text-base text-gray-800 dark:text-slate-300 max-w-2xl leading-relaxed">
-            {config.fits.subhead}
-          </p>
-        </div>
-        <div className="grid md:grid-cols-2 gap-6">
-          <div className="relative">
-            <div
-              className="absolute top-2.5 left-2.5 -right-2.5 -bottom-2.5"
-              aria-hidden="true"
-              style={indigoShadowStyle}
-            />
-            <div className="relative bg-white dark:bg-slate-900 border-2 border-indigo-400 dark:border-indigo-500 p-6 h-full">
-              <div className="font-mono text-[11px] uppercase tracking-[0.2em] text-indigo-600 dark:text-indigo-400 mb-3">
-                Reach for ParadeDB when
+        <section>
+          <div className="mb-8">
+            <Badge className="mb-4">Which fits when</Badge>
+            <h2 className="text-2xl md:text-3xl font-bold tracking-tight text-indigo-950 dark:text-white mb-3">
+              Pick by your workload.
+            </h2>
+            <p className="text-base text-gray-800 dark:text-slate-300 max-w-2xl leading-relaxed">
+              {config.fits.subhead}
+            </p>
+          </div>
+          <div className="grid md:grid-cols-2 gap-6">
+            <div className="relative">
+              <div
+                className="absolute top-2.5 left-2.5 -right-2.5 -bottom-2.5"
+                aria-hidden="true"
+                style={indigoShadowStyle}
+              />
+              <div className="relative bg-white dark:bg-slate-900 border-2 border-indigo-400 dark:border-indigo-500 p-6 h-full">
+                <div className="font-mono text-[11px] uppercase tracking-[0.2em] text-indigo-600 dark:text-indigo-400 mb-3">
+                  Reach for ParadeDB when
+                </div>
+                <ul className="space-y-3">
+                  {config.fits.us.map((item, i) => (
+                    <li
+                      key={i}
+                      className="text-sm sm:text-base text-slate-800 dark:text-slate-200 leading-relaxed flex gap-3"
+                    >
+                      <span className="font-mono text-slate-400 dark:text-slate-600 select-none">
+                        ·
+                      </span>
+                      <span>{item}</span>
+                    </li>
+                  ))}
+                </ul>
               </div>
-              <ul className="space-y-3">
-                {config.fits.us.map((item, i) => (
-                  <li
-                    key={i}
-                    className="text-sm sm:text-base text-slate-800 dark:text-slate-200 leading-relaxed flex gap-3"
-                  >
-                    <span className="font-mono text-slate-400 dark:text-slate-600 select-none">
-                      ·
-                    </span>
-                    <span>{item}</span>
-                  </li>
-                ))}
-              </ul>
+            </div>
+            <div className="relative">
+              <div
+                className="absolute top-2.5 left-2.5 -right-2.5 -bottom-2.5"
+                aria-hidden="true"
+                style={slateShadowStyle}
+              />
+              <div className="relative bg-white dark:bg-slate-900 border-2 border-slate-300 dark:border-slate-600 p-6 h-full">
+                <div className="font-mono text-[11px] uppercase tracking-[0.2em] text-slate-600 dark:text-slate-400 mb-3">
+                  Reach for {config.competitor.name} when
+                </div>
+                <ul className="space-y-3">
+                  {config.fits.them.map((item, i) => (
+                    <li
+                      key={i}
+                      className="text-sm sm:text-base text-slate-800 dark:text-slate-200 leading-relaxed flex gap-3"
+                    >
+                      <span className="font-mono text-slate-400 dark:text-slate-600 select-none">
+                        ·
+                      </span>
+                      <span>{item}</span>
+                    </li>
+                  ))}
+                </ul>
+              </div>
             </div>
           </div>
-          <div className="relative">
-            <div
-              className="absolute top-2.5 left-2.5 -right-2.5 -bottom-2.5"
-              aria-hidden="true"
-              style={slateShadowStyle}
-            />
-            <div className="relative bg-white dark:bg-slate-900 border-2 border-slate-300 dark:border-slate-600 p-6 h-full">
-              <div className="font-mono text-[11px] uppercase tracking-[0.2em] text-slate-600 dark:text-slate-400 mb-3">
-                Reach for {config.competitor.name} when
-              </div>
-              <ul className="space-y-3">
-                {config.fits.them.map((item, i) => (
-                  <li
-                    key={i}
-                    className="text-sm sm:text-base text-slate-800 dark:text-slate-200 leading-relaxed flex gap-3"
-                  >
-                    <span className="font-mono text-slate-400 dark:text-slate-600 select-none">
-                      ·
-                    </span>
-                    <span>{item}</span>
-                  </li>
-                ))}
-              </ul>
-            </div>
-          </div>
-        </div>
-      </section>
+        </section>
       )}
     </div>
   );


### PR DESCRIPTION
# Ticket(s) Closed

None

## What

Runs Prettier over the five files added by #368. Formatting only, no behavior change.

## Why

`Lint TypeScript Files` currently fails on `main`, and therefore on every PR branched from it (e.g. #369):

```
[warn] src/app/vs/layout-client.tsx
[warn] src/app/vs/postgresql/page.tsx
[warn] src/components/vs/VsBenchmarkPanel.tsx
[warn] src/components/vs/VsBenchSummary.tsx
[warn] src/components/vs/VsPage.tsx
[warn] Code style issues found in 5 files. Run Prettier with --write to fix.
```

## How

**`src/app/vs/`, `src/components/vs/`**

- Ran `pnpm exec prettier --write "src/**/*.{ts,tsx}" --ignore-path .prettierignore`, i.e. the repo-pinned Prettier the lint workflow uses.
- Changes are whitespace, line-wrapping, and Prettier's trailing commas: the `ROWS` / config object literals in `VsBenchSummary.tsx` and `VsBenchmarkPanel.tsx` expand to one property per line, and a few JSX attribute and expression wraps shift.

## Tests

- `pnpm exec prettier --check "src/**/*.{ts,tsx}" --ignore-path .prettierignore` passes
- `pnpm exec tsc --noEmit` passes
- Normalizing each file (strip all whitespace, drop trailing commas before `}`/`]`/`)`) makes all five byte-identical to their `main` versions, so nothing but formatting changed
- JSX text semantics preserved: the two re-wrapped inline runs in `postgresql/page.tsx` render unchanged — `RRF</A>` + newline + `-fused` still yields `RRF-fused` (leading whitespace containing a newline is stripped), and the `columnar` / `storage,` line break collapses to a single space
