### PR TITLE
fix: Make install.sh POSIX-compatible so it runs under sh

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -17,10 +17,8 @@
 # To uninstall, just run: docker rm -f paradedb && docker volume rm paradedb_data
 # ---------------------------------------------------------
 
-# The body of this script is POSIX-compatible, so it runs under dash (which is
-# /bin/sh on Debian and Ubuntu) as well as bash. Keep it that way: no `local`,
-# no `$'...'` escapes, no `set -o pipefail`. People pipe this into `sh` from
-# stale copies of the install command, and dash aborts on the first bashism.
+# The body of this script is intentionally POSIX-compatible, so it runs
+# under dash (which is /bin/sh on Debian and Ubuntu) as well as bash.
 #
 # `pipefail` is intentionally omitted because dash does not implement it.
 # @paradedb-skip-check-pipefail

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -19,9 +19,7 @@
 # ---------------------------------------------------------
 
 # The body of this script is intentionally POSIX-compatible, so it runs
-# under dash (which is /bin/sh on Debian and Ubuntu) as well as bash. The
-# `# shellcheck shell=sh` directive at the top enforces that in CI: it
-# overrides the shebang, so any bashism fails the build.
+# under dash (which is /bin/sh on Debian and Ubuntu) as well as bash.
 #
 # `pipefail` is intentionally omitted because dash does not implement it.
 # @paradedb-skip-check-pipefail

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -17,8 +17,15 @@
 # To uninstall, just run: docker rm -f paradedb && docker volume rm paradedb_data
 # ---------------------------------------------------------
 
+# The body of this script is POSIX-compatible, so it runs under dash (which is
+# /bin/sh on Debian and Ubuntu) as well as bash. Keep it that way: no `local`,
+# no `$'...'` escapes, no `set -o pipefail`. People pipe this into `sh` from
+# stale copies of the install command, and dash aborts on the first bashism.
+#
+# `pipefail` is intentionally omitted because dash does not implement it.
+# @paradedb-skip-check-pipefail
 # Exit on subcommand errors
-set -Eeuo pipefail
+set -eu
 
 SILENT=false
 for arg in "$@"; do
@@ -45,12 +52,13 @@ PG_DATABASE="${PDB_PG_DATABASE:-paradedb}"
 
 # Color support
 if [ -t 1 ] && [ "$(tput colors 2>/dev/null)" -ge 8 ] 2>/dev/null; then
-  RED=$'\033[0;31m'
-  GREEN=$'\033[0;32m'
-  CYAN=$'\033[0;36m'
-  PURPLE=$'\033[38;5;99m'
-  BOLD=$'\033[1m'
-  RESET=$'\033[0m'
+  # printf rather than $'...', which dash does not understand
+  RED=$(printf '\033[0;31m')
+  GREEN=$(printf '\033[0;32m')
+  CYAN=$(printf '\033[0;36m')
+  PURPLE=$(printf '\033[38;5;99m')
+  BOLD=$(printf '\033[1m')
+  RESET=$(printf '\033[0m')
 else
   RED=''
   GREEN=''
@@ -184,8 +192,8 @@ else
 fi
 
 wait_for_postgres() {
-  local retries=0
-  local max_retries=10
+  retries=0
+  max_retries=10
   until docker exec "$CONTAINER_NAME" pg_isready -U "$PG_USER" -d "$PG_DATABASE" > /dev/null 2>&1; do
     retries=$((retries + 1))
     if [ "$retries" -ge "$max_retries" ]; then

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# shellcheck shell=sh
 
 # ---------------------------------------------------------
 # Hi, savvy user! Thanks for reading the source.
@@ -18,7 +19,9 @@
 # ---------------------------------------------------------
 
 # The body of this script is intentionally POSIX-compatible, so it runs
-# under dash (which is /bin/sh on Debian and Ubuntu) as well as bash.
+# under dash (which is /bin/sh on Debian and Ubuntu) as well as bash. The
+# `# shellcheck shell=sh` directive at the top enforces that in CI: it
+# overrides the shebang, so any bashism fails the build.
 #
 # `pipefail` is intentionally omitted because dash does not implement it.
 # @paradedb-skip-check-pipefail

--- a/src/components/ui/Hero.tsx
+++ b/src/components/ui/Hero.tsx
@@ -9,7 +9,7 @@ import { DarkModeOverlay } from "./DarkModeOverlay";
 import Code from "@/components/Code";
 import CopyToClipboard from "@/components/CopyToClipboard";
 
-const installCommand = `curl -fsSL https://paradedb.com/install.sh | bash`;
+const installCommand = `curl -fsSL https://paradedb.com/install.sh | sh`;
 
 export default async function Hero() {
   return (


### PR DESCRIPTION
# Ticket(s) Closed

None

## What

Removes the three Bash-only constructs from `scripts/install.sh` so the script runs under `sh` (dash) as well as `bash`, makes CI enforce that going forward, and points the homepage command back at the shorter `| sh`.

## Why

#369 fixed the command the homepage renders by switching it to `| bash`, but stale `| sh` copies of it live in blog posts, shell history, and LLM output, and they all fail the same way:

```
ubuntu@host:~$ curl -fsSL https://paradedb.com/install.sh | sh
sh: 21: set: Illegal option -o pipefail
```

Making the body portable fixes those too, and covers the case a bash-only fix cannot: hosts with no bash installed at all, such as Alpine/busybox, where `| bash` fails outright.

`shellcheck -s sh` found only three bashisms in the 218-line script, so the conversion is ~10 lines.

## How

**`scripts/install.sh`**

- `set -Eeuo pipefail` → `set -eu`. `-E` was inert (the script installs no `ERR` trap). `pipefail` is dropped because dash does not implement it — note that POSIX Issue 8 added `pipefail`, so "POSIX-compliant" and "dash-compatible" are not the same target here, and dash is the one that matters.
- Colors: `RED=$'\033[0;31m'` → `RED=$(printf '\033[0;31m')` for all six variables. `$'...'` is a bash/ksh/zsh extension; `\ooo` octal escapes are specified for POSIX `printf`.
- `wait_for_postgres`: dropped `local` from `retries` and `max_retries`. `local` is not in POSIX; the function is called once and the script exits after it, so scope leakage is harmless.
- Added a `# shellcheck shell=sh` directive on line 2. This is what keeps the script portable: the directive overrides the shebang, so CI's existing `shellcheck -x -P scripts` run now checks the file as POSIX sh and fails on any future bashism. Without it, the POSIX property would be a comment that nothing enforces.

**`src/components/ui/Hero.tsx`**

- Install command: `| bash` → `| sh`, reverting that part of #369 now that the script body supports it.

**Deliberately unchanged**

- The shebang stays `#!/bin/bash`. It governs `./install.sh` only, and is a comment when the script is piped into `sh` — so no change is needed to the shared `lint-bash.yml`, which requires a bash shebang on every `*.sh`.
- `lint-bash.yml`'s strict-mode check is satisfied via its existing `# @paradedb-skip-check-pipefail` escape hatch rather than by editing the workflow.

**Loss of `pipefail`, assessed**

Four pipelines exist. `docker ps … | grep -q` and `docker volume ls … | grep -q` are `if` conditions where only `grep`'s status is meaningful. The other two are the password generators (`od … | tr`, `dd … | tr | head`); if the left-hand side failed, the fallback path still produces a password rather than an empty one. No pipeline silently produces a wrong result.

## Tests

Verified against real `dash` (`/bin/dash`), with a stub `docker` on `PATH`, piping the script into the shell exactly as `curl … | sh` delivers it:

- `shellcheck -x -P scripts scripts/install.sh` (the CI invocation) passes, and now checks POSIX rather than bash
- That guard is live, not cosmetic: injecting `local retries=0` trips SC3043 and injecting `ARR=(a b)` trips SC3030, and both make the CI command exit non-zero
- `lint-bash.yml`'s shebang and strict-mode greps both still match
- Full install path under dash: pull → run → `pg_isready` retry loop → password print → psql launch, exit 0. Colors, spinner, and the word-list password all render correctly
- Interactive prompt driven over a real pty with `expect`, under both shells: `y` and `Y` proceed to psql, `n` aborts cleanly. dash and bash behave identically
- Branch coverage under dash: already-running container, pre-existing volume (errors, exit 1), Docker not installed (errors, exit 1)
- Non-tty run emits zero ANSI escape sequences, so the `[ -t 1 ]` color guard still works
- `pnpm exec tsc --noEmit` and `pnpm exec prettier --check` pass
- Untested: busybox `ash`, which is not available on the machine this was verified on
