### PR TITLE
feat: host documentation at /docs

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -23,6 +23,16 @@ const nextConfig = {
 
   async rewrites() {
     return [
+      // Mintlify is configured to serve this project from the /docs base path.
+      // Rewrites keep the public URL on paradedb.com while proxying the docs.
+      {
+        source: "/docs",
+        destination: "https://paradedb.mintlify.dev/docs",
+      },
+      {
+        source: "/docs/:path*",
+        destination: "https://paradedb.mintlify.dev/docs/:path*",
+      },
       {
         source: "/install.sh",
         destination: "/api/install",
@@ -96,6 +106,18 @@ const nextConfig = {
         source: "/:path*",
         has: [{ type: "host", value: "customers.paradedb.com" }],
         destination: "https://www.paradedb.com/customers/:path*",
+        permanent: true,
+      },
+      {
+        source: "/",
+        has: [{ type: "host", value: "docs.paradedb.com" }],
+        destination: "https://www.paradedb.com/docs",
+        permanent: true,
+      },
+      {
+        source: "/:path*",
+        has: [{ type: "host", value: "docs.paradedb.com" }],
+        destination: "https://www.paradedb.com/docs/:path*",
         permanent: true,
       },
       {


### PR DESCRIPTION
## Summary

- proxy `paradedb.com/docs` and all nested documentation routes to ParadeDB's Mintlify project
- redirect legacy `docs.paradedb.com` URLs to the equivalent canonical `www.paradedb.com/docs` URLs
- preserve every existing documentation path during the migration

## Deployment order

Do not merge until the Mintlify prerequisite is complete:

1. In Mintlify **Custom domain setup**, enable **Host at `/docs`** and enter `paradedb.com`.
2. Verify `https://paradedb.mintlify.dev/docs/welcome/introduction` returns 200. It currently returns 404, so the mode is not active yet.
3. Merge and deploy this PR.
4. Add `docs.paradedb.com` to the website Vercel project, then move its DNS away from Mintlify so requests reach these host-based redirects.
5. Verify representative pages and only then update canonical links across the website and docs configuration.

## Verification

- `node --check next.config.mjs`
- Prettier check
- `git diff --check`
- confirmed `paradedb.mintlify.dev` is the Mintlify project origin
- compared the rewrites with Mintlify's official Vercel `/docs` configuration

The existing untracked `pnpm-workspace.yaml` was left untouched.