### PR TITLE
chore: Bump Docker pulls to 2.5M+

### DIFF
--- a/src/components/ui/CommunityProof.tsx
+++ b/src/components/ui/CommunityProof.tsx
@@ -39,7 +39,7 @@ export default function CommunityProof() {
                     <DockerLogo className="w-full h-full dark:brightness-0 dark:invert" />
                   </div>
                   <div className="text-2xl font-bold text-indigo-950 dark:text-white mb-2">
-                    2M+
+                    2.5M+
                   </div>
                   <div className="font-semibold text-slate-900 dark:text-slate-100 mb-2">
                     Docker deployments


### PR DESCRIPTION
## Summary

- update the homepage Docker deployment count from 2M+ to 2.5M+

## Testing

- `node_modules/.bin/eslint src/components/ui/CommunityProof.tsx`
- `git diff --check`