### PR TITLE
fix: return agent-friendly Markdown 404s

### DIFF
--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -10,6 +10,37 @@ const ARTICLE_DEPTH: Record<string, number> = {
   learn: 3, // /learn/<section>/<slug>
 };
 
+// Non-article pages that should continue to the normal HTML application when
+// a client requests Markdown. Article pages are handled separately above.
+const HTML_PAGE_PATHS = new Set([
+  "/brand",
+  "/blog",
+  "/cloud",
+  "/cloud/confirmed",
+  "/contact",
+  "/customers",
+  "/learn",
+  "/legal/privacy",
+  "/legal/terms",
+  "/pricing",
+  "/preview",
+  "/preview/default",
+  "/preview/variant-b",
+  "/privacy",
+  "/slack",
+  "/terms",
+  "/vs/postgresql",
+]);
+
+const MARKDOWN_NOT_FOUND = `# 404 Not Found
+
+No page exists at this URL.
+
+- [ParadeDB content index](https://www.paradedb.com/llms.txt)
+- [Documentation](https://docs.paradedb.com/welcome/introduction)
+- [Sitemap](https://www.paradedb.com/sitemap.xml)
+`;
+
 function clientPrefersMarkdown(accept: string | null): boolean {
   if (!accept) return false;
 
@@ -44,11 +75,12 @@ function withAcceptVary(response: NextResponse): NextResponse {
 
 export function proxy(req: NextRequest) {
   const { pathname } = req.nextUrl;
+  const prefersMarkdown = clientPrefersMarkdown(req.headers.get("accept"));
 
   // Give agents a concise representation at the canonical homepage URL while
   // keeping the browser experience unchanged. Vary keeps CDN variants apart.
   if (pathname === "/") {
-    if (clientPrefersMarkdown(req.headers.get("accept"))) {
+    if (prefersMarkdown) {
       const url = req.nextUrl.clone();
       url.pathname = "/llms.txt";
       const response = NextResponse.rewrite(url);
@@ -59,11 +91,11 @@ export function proxy(req: NextRequest) {
     return withAcceptVary(NextResponse.next());
   }
 
-  if (pathname.endsWith(".md") || !isLeafArticle(pathname)) {
+  if (pathname.endsWith(".md")) {
     return withAcceptVary(NextResponse.next());
   }
 
-  if (clientPrefersMarkdown(req.headers.get("accept"))) {
+  if (prefersMarkdown && isLeafArticle(pathname)) {
     const url = req.nextUrl.clone();
     url.pathname = `${pathname.replace(/\/$/, "")}.md`;
     const response = NextResponse.rewrite(url);
@@ -71,9 +103,23 @@ export function proxy(req: NextRequest) {
     return withAcceptVary(response);
   }
 
+  if (prefersMarkdown && !HTML_PAGE_PATHS.has(pathname.replace(/\/$/, ""))) {
+    return withAcceptVary(
+      new NextResponse(MARKDOWN_NOT_FOUND, {
+        status: 404,
+        headers: {
+          "Cache-Control": "public, max-age=0, must-revalidate",
+          "Content-Type": "text/markdown; charset=utf-8",
+        },
+      }),
+    );
+  }
+
   return withAcceptVary(NextResponse.next());
 }
 
 export const config = {
-  matcher: ["/", "/blog/:path*", "/customers/:path*", "/learn/:path*"],
+  matcher: [
+    "/((?!api|mcp|_next/static|_next/image|favicon.ico|robots.txt|sitemap.xml|sitemap-0.xml|llms.txt|llms-full.txt|feed.xml|.*\\..*).*)",
+  ],
 };


### PR DESCRIPTION
## Summary
- return a minimal Markdown recovery page with a genuine HTTP 404 when a client explicitly prefers text/markdown
- point agents to llms.txt, the documentation, and the sitemap
- preserve the existing HTML 404 for browsers and keep CDN variants separate with Vary: Accept
- extend content negotiation to unknown public paths while bypassing assets and service endpoints

## Verification
- corepack pnpm build
- node_modules/.bin/eslint src/proxy.ts
- node_modules/.bin/prettier --check src/proxy.ts
- git diff --check
- local browser request: 404 text/html
- local request with Accept: text/markdown: 404 text/markdown with a 224-byte recovery body