### PR TITLE
fix: polish agent readiness metadata

### DIFF
--- a/public/.well-known/mcp.json
+++ b/public/.well-known/mcp.json
@@ -2,6 +2,13 @@
   "name": "paradedb",
   "description": "MCP server for ParadeDB's blog posts, customer stories, and learn articles. Search and read ParadeDB's content for full-text search and analytics in Postgres.",
   "version": "1.0.0",
+  "icons": [
+    {
+      "src": "https://www.paradedb.com/brand/paradedb-logomark-light.svg",
+      "mimeType": "image/svg+xml",
+      "sizes": ["any"]
+    }
+  ],
   "servers": [
     {
       "url": "https://www.paradedb.com/mcp",

--- a/src/app/mcp/route.ts
+++ b/src/app/mcp/route.ts
@@ -165,6 +165,7 @@ const handler = createMcpHandler(
         title: "Get ParadeDB product info",
         description:
           "Get a structured overview of ParadeDB: what it is, how to install it, and key links (docs, GitHub, blog). Useful for grounding before answering questions.",
+        inputSchema: z.object({}),
         outputSchema: productInfoSchema,
         annotations: { title: "Get ParadeDB product info", ...READ_ONLY },
       },

--- a/src/components/ui/SearchFeaturesClient.tsx
+++ b/src/components/ui/SearchFeaturesClient.tsx
@@ -104,9 +104,9 @@ export default function SearchFeaturesClient({
                               {bullet.icon}
                             </div>
                             <div className="flex flex-col gap-1">
-                              <h4 className="font-semibold text-base sm:text-lg text-indigo-950 dark:text-white tracking-tight">
+                              <h3 className="font-semibold text-base sm:text-lg text-indigo-950 dark:text-white tracking-tight">
                                 {bullet.title}
-                              </h4>
+                              </h3>
                               <p className="text-sm sm:text-base text-gray-600 dark:text-slate-400 leading-relaxed">
                                 {bullet.description}
                               </p>

--- a/src/lib/structured-data.ts
+++ b/src/lib/structured-data.ts
@@ -32,6 +32,14 @@ export function organizationSchema() {
     },
     description: siteConfig.description,
     email: mailto(email.HELLO),
+    address: {
+      "@type": "PostalAddress",
+      streetAddress: "169 Madison Avenue, #2470",
+      addressLocality: "New York",
+      addressRegion: "NY",
+      postalCode: "10016",
+      addressCountry: "US",
+    },
     contactPoint: [
       {
         "@type": "ContactPoint",


### PR DESCRIPTION
## Summary
- correct homepage feature-card heading hierarchy from h4 to h3
- add ParadeDB's already-public mailing address to Organization JSON-LD
- add a same-origin branded icon to the MCP manifest using the MCP icons shape
- declare an explicit empty input schema for get_product_info so every MCP tool has a typed input contract

## Why
These address the legitimate partial checks from the expanded Is Agentic audit without publishing placeholder API, OAuth, or Cloud metadata before those surfaces exist.

## Verification
- corepack pnpm build
- targeted ESLint on all changed TypeScript files
- Prettier check on all changed files
- git diff --check
- confirmed the generated homepage contains the PostalAddress JSON-LD