### PR TITLE
fix: proxy docs through configured Mintlify origin

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -27,11 +27,11 @@ const nextConfig = {
       // Rewrites keep the public URL on paradedb.com while proxying the docs.
       {
         source: "/docs",
-        destination: "https://paradedb.mintlify.dev/docs",
+        destination: "https://docs-origin.paradedb.com/docs",
       },
       {
         source: "/docs/:path*",
-        destination: "https://paradedb.mintlify.dev/docs/:path*",
+        destination: "https://docs-origin.paradedb.com/docs/:path*",
       },
       {
         source: "/install.sh",


### PR DESCRIPTION
## Summary

- proxy /docs through the connected docs-origin.paradedb.com Mintlify domain
- replace the paradedb.mintlify.dev target, which currently returns 404 for /docs routes

## Verification

- https://docs-origin.paradedb.com/docs/welcome/introduction returns 200
- node --check next.config.mjs
- Prettier check
- git diff --check

The existing untracked pnpm-workspace.yaml was left untouched.