### PR TITLE
fix: use documented Mintlify site origin

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -27,11 +27,11 @@ const nextConfig = {
       // Rewrites keep the public URL on paradedb.com while proxying the docs.
       {
         source: "/docs",
-        destination: "https://docs-origin.paradedb.com/docs",
+        destination: "https://paradedb.mintlify.site/docs",
       },
       {
         source: "/docs/:path*",
-        destination: "https://docs-origin.paradedb.com/docs/:path*",
+        destination: "https://paradedb.mintlify.site/docs/:path*",
       },
       {
         source: "/install.sh",


### PR DESCRIPTION
## Summary

- replace the temporary docs-origin.paradedb.com proxy target with the documented paradedb.mintlify.site origin
- keep the existing /docs rewrite behavior unchanged

## Verification

- https://paradedb.mintlify.site/docs/welcome/introduction returns 200
- node --check next.config.mjs
- Prettier check
- git diff --check

Reference: https://www.mintlify.com/docs/deploy/vercel

The existing untracked pnpm-workspace.yaml was left untouched.