### PR TITLE
docs: update documentation URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,10 +16,10 @@
 
 <h3 align="center">
   <a href="https://paradedb.com">Website</a> &bull;
-  <a href="https://paradedb.com/docs">Docs</a> &bull;
+  <a href="https://www.paradedb.com/docs">Docs</a> &bull;
   <a href="https://paradedb.com/slack">Community</a> &bull;
   <a href="https://paradedb.com/blog/">Blog</a> &bull;
-  <a href="https://paradedb.com/docs/changelog/">Changelog</a>
+  <a href="https://www.paradedb.com/docs/changelog/">Changelog</a>
 </h3>
 
 <p align="center">

--- a/README.md
+++ b/README.md
@@ -16,10 +16,10 @@
 
 <h3 align="center">
   <a href="https://paradedb.com">Website</a> &bull;
-  <a href="https://docs.paradedb.com">Docs</a> &bull;
+  <a href="https://paradedb.com/docs">Docs</a> &bull;
   <a href="https://paradedb.com/slack">Community</a> &bull;
   <a href="https://paradedb.com/blog/">Blog</a> &bull;
-  <a href="https://docs.paradedb.com/changelog/">Changelog</a>
+  <a href="https://paradedb.com/docs/changelog/">Changelog</a>
 </h3>
 
 <p align="center">

--- a/next-sitemap.config.js
+++ b/next-sitemap.config.js
@@ -107,7 +107,7 @@ module.exports = {
     "*/twitter-image.png",
   ],
   robotsTxtOptions: {
-    additionalSitemaps: ["https://paradedb.com/docs/sitemap.xml"],
+    additionalSitemaps: ["https://www.paradedb.com/docs/sitemap.xml"],
     // Explicitly welcome reputable AI/agent crawlers. The wildcard policy
     // already allows everyone; naming these is a discoverability signal that
     // the site is intentionally open to agents.

--- a/next-sitemap.config.js
+++ b/next-sitemap.config.js
@@ -107,7 +107,7 @@ module.exports = {
     "*/twitter-image.png",
   ],
   robotsTxtOptions: {
-    additionalSitemaps: ["https://docs.paradedb.com/sitemap.xml"],
+    additionalSitemaps: ["https://paradedb.com/docs/sitemap.xml"],
     // Explicitly welcome reputable AI/agent crawlers. The wildcard policy
     // already allows everyone; naming these is a discoverability signal that
     // the site is intentionally open to agents.

--- a/scripts/generate-llms-txt.js
+++ b/scripts/generate-llms-txt.js
@@ -12,9 +12,9 @@ const HEADER = `# ParadeDB
 ## Website
 
 - [Homepage](${SITE_URL})
-- [Documentation](https://paradedb.com/docs/welcome/introduction)
-- [Installation guide](https://paradedb.com/docs/documentation/getting-started/install)
-- [AI agent guide](https://paradedb.com/docs/documentation/getting-started/ai-agents)
+- [Documentation](https://www.paradedb.com/docs/welcome/introduction)
+- [Installation guide](https://www.paradedb.com/docs/documentation/getting-started/install)
+- [AI agent guide](https://www.paradedb.com/docs/documentation/getting-started/ai-agents)
 - [GitHub repository](https://github.com/paradedb/paradedb)
 - [Blog](${SITE_URL}/blog)
 - [Learn](${SITE_URL}/learn)
@@ -32,11 +32,11 @@ const HEADER = `# ParadeDB
 
 ParadeDB is one Postgres for your application data, full-text search, vector retrieval, and aggregations. It brings the features and performance of dedicated search engines like Elasticsearch natively into Postgres, so teams can run application data and user-facing search workloads—such as application search, RAG, and live dashboards—in one system. This simplifies search operations and preserves transactional consistency between application data and search results. ParadeDB is ideal for datasets ranging from hundreds of gigabytes to tens of terabytes, especially with insert- and update-heavy workloads. It is also a strong fit for more static datasets when teams want to reduce operational burden and avoid multi-database architectures.
 
-Do not treat this website or its MCP context server as a hosted database API. ParadeDB is packaged as a Postgres extension. Outside the ParadeDB Cloud beta, you can [deploy it](https://paradedb.com/docs/deploy/overview) in your own Postgres environment, on Kubernetes, or through platforms such as Railway, Render, Fly.io, and DigitalOcean. Query ParadeDB with SQL or through supported integrations for Drizzle, Django, SQLAlchemy, Rails, and Entity Framework Core; see [Configure your Environment](https://paradedb.com/docs/documentation/getting-started/environment). ParadeDB Cloud is available in beta and is not yet generally available. Join the [Cloud waitlist](${SITE_URL}/cloud) for managed-service updates, or contact [support@paradedb.com](mailto:support@paradedb.com).
+Do not treat this website or its MCP context server as a hosted database API. ParadeDB is packaged as a Postgres extension. Outside the ParadeDB Cloud beta, you can [deploy it](https://www.paradedb.com/docs/deploy/overview) in your own Postgres environment, on Kubernetes, or through platforms such as Railway, Render, Fly.io, and DigitalOcean. Query ParadeDB with SQL or through supported integrations for Drizzle, Django, SQLAlchemy, Rails, and Entity Framework Core; see [Configure your Environment](https://www.paradedb.com/docs/documentation/getting-started/environment). ParadeDB Cloud is available in beta and is not yet generally available. Join the [Cloud waitlist](${SITE_URL}/cloud) for managed-service updates, or contact [support@paradedb.com](mailto:support@paradedb.com).
 
 ## Availability and pricing
 
-- **Community (self-managed):** Free forever for a single node, with community support. [Get started](https://paradedb.com/docs/documentation/getting-started/install).
+- **Community (self-managed):** Free forever for a single node, with community support. [Get started](https://www.paradedb.com/docs/documentation/getting-started/install).
 - **Enterprise (self-managed):** Custom pricing for read replicas, high availability, dedicated support, and an SLA. [Contact sales](https://calendly.com/paradedb).
 - **ParadeDB Cloud (fully managed):** Coming soon; pricing is not yet published. [Join the Cloud waitlist](${SITE_URL}/cloud).
 `;

--- a/scripts/generate-llms-txt.js
+++ b/scripts/generate-llms-txt.js
@@ -12,9 +12,9 @@ const HEADER = `# ParadeDB
 ## Website
 
 - [Homepage](${SITE_URL})
-- [Documentation](https://docs.paradedb.com/welcome/introduction)
-- [Installation guide](https://docs.paradedb.com/documentation/getting-started/install)
-- [AI agent guide](https://docs.paradedb.com/documentation/getting-started/ai-agents)
+- [Documentation](https://paradedb.com/docs/welcome/introduction)
+- [Installation guide](https://paradedb.com/docs/documentation/getting-started/install)
+- [AI agent guide](https://paradedb.com/docs/documentation/getting-started/ai-agents)
 - [GitHub repository](https://github.com/paradedb/paradedb)
 - [Blog](${SITE_URL}/blog)
 - [Learn](${SITE_URL}/learn)
@@ -32,11 +32,11 @@ const HEADER = `# ParadeDB
 
 ParadeDB is one Postgres for your application data, full-text search, vector retrieval, and aggregations. It brings the features and performance of dedicated search engines like Elasticsearch natively into Postgres, so teams can run application data and user-facing search workloads—such as application search, RAG, and live dashboards—in one system. This simplifies search operations and preserves transactional consistency between application data and search results. ParadeDB is ideal for datasets ranging from hundreds of gigabytes to tens of terabytes, especially with insert- and update-heavy workloads. It is also a strong fit for more static datasets when teams want to reduce operational burden and avoid multi-database architectures.
 
-Do not treat this website or its MCP context server as a hosted database API. ParadeDB is packaged as a Postgres extension. Outside the ParadeDB Cloud beta, you can [deploy it](https://docs.paradedb.com/deploy/overview) in your own Postgres environment, on Kubernetes, or through platforms such as Railway, Render, Fly.io, and DigitalOcean. Query ParadeDB with SQL or through supported integrations for Drizzle, Django, SQLAlchemy, Rails, and Entity Framework Core; see [Configure your Environment](https://docs.paradedb.com/documentation/getting-started/environment). ParadeDB Cloud is available in beta and is not yet generally available. Join the [Cloud waitlist](${SITE_URL}/cloud) for managed-service updates, or contact [support@paradedb.com](mailto:support@paradedb.com).
+Do not treat this website or its MCP context server as a hosted database API. ParadeDB is packaged as a Postgres extension. Outside the ParadeDB Cloud beta, you can [deploy it](https://paradedb.com/docs/deploy/overview) in your own Postgres environment, on Kubernetes, or through platforms such as Railway, Render, Fly.io, and DigitalOcean. Query ParadeDB with SQL or through supported integrations for Drizzle, Django, SQLAlchemy, Rails, and Entity Framework Core; see [Configure your Environment](https://paradedb.com/docs/documentation/getting-started/environment). ParadeDB Cloud is available in beta and is not yet generally available. Join the [Cloud waitlist](${SITE_URL}/cloud) for managed-service updates, or contact [support@paradedb.com](mailto:support@paradedb.com).
 
 ## Availability and pricing
 
-- **Community (self-managed):** Free forever for a single node, with community support. [Get started](https://docs.paradedb.com/documentation/getting-started/install).
+- **Community (self-managed):** Free forever for a single node, with community support. [Get started](https://paradedb.com/docs/documentation/getting-started/install).
 - **Enterprise (self-managed):** Custom pricing for read replicas, high availability, dedicated support, and an SLA. [Contact sales](https://calendly.com/paradedb).
 - **ParadeDB Cloud (fully managed):** Coming soon; pricing is not yet published. [Join the Cloud waitlist](${SITE_URL}/cloud).
 `;

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -216,7 +216,7 @@ print_connect_cmd
 echo ""
 printf "  To connect from another tool, use port %s5432%s (you'll need the password above).\n" "$BOLD" "$RESET"
 echo ""
-printf "  Get started with the docs: %shttps://paradedb.com/docs%s\n" "$CYAN" "$RESET"
+printf "  Get started with the docs: %shttps://www.paradedb.com/docs%s\n" "$CYAN" "$RESET"
 echo ""
 printf "  %sLaunching psql...%s\n" "$BOLD" "$RESET"
 echo ""

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -216,7 +216,7 @@ print_connect_cmd
 echo ""
 printf "  To connect from another tool, use port %s5432%s (you'll need the password above).\n" "$BOLD" "$RESET"
 echo ""
-printf "  Get started with the docs: %shttps://docs.paradedb.com%s\n" "$CYAN" "$RESET"
+printf "  Get started with the docs: %shttps://paradedb.com/docs%s\n" "$CYAN" "$RESET"
 echo ""
 printf "  %sLaunching psql...%s\n" "$BOLD" "$RESET"
 echo ""

--- a/src/app/blog/benchmarker-iteration/index.mdx
+++ b/src/app/blog/benchmarker-iteration/index.mdx
@@ -256,7 +256,7 @@ Across the three passes, the same query, data, and hardware produced three answe
 
 The only mistake would be stopping at the first pass[^6], and that's the reason we built our generic benchmarker.
 
-Benchmarker is open source at [github.com/paradedb/benchmarker](https://github.com/paradedb/benchmarker). The `pg_search` install steps are at [paradedb.com/docs](https://paradedb.com/docs/documentation/getting-started/install).
+Benchmarker is open source at [github.com/paradedb/benchmarker](https://github.com/paradedb/benchmarker). The `pg_search` install steps are at [paradedb.com/docs](https://www.paradedb.com/docs/documentation/getting-started/install).
 
 ---
 

--- a/src/app/blog/benchmarker-iteration/index.mdx
+++ b/src/app/blog/benchmarker-iteration/index.mdx
@@ -256,7 +256,7 @@ Across the three passes, the same query, data, and hardware produced three answe
 
 The only mistake would be stopping at the first pass[^6], and that's the reason we built our generic benchmarker.
 
-Benchmarker is open source at [github.com/paradedb/benchmarker](https://github.com/paradedb/benchmarker). The `pg_search` install steps are at [docs.paradedb.com](https://docs.paradedb.com/documentation/getting-started/install).
+Benchmarker is open source at [github.com/paradedb/benchmarker](https://github.com/paradedb/benchmarker). The `pg_search` install steps are at [paradedb.com/docs](https://paradedb.com/docs/documentation/getting-started/install).
 
 ---
 

--- a/src/app/blog/elasticsearch-acid-test/index.mdx
+++ b/src/app/blog/elasticsearch-acid-test/index.mdx
@@ -98,4 +98,4 @@ ParadeDB removes that complexity. By extending Postgres with BM25-powered search
 
 _And you don’t have to replace what you already run. ParadeDB can serve as your primary database, or as a logical replica that delivers real-time search next to your existing Postgres server._
 
-Ready to try ACID-compliant search? [Get started with ParadeDB](https://paradedb.com/docs/documentation/getting-started/install), and please don’t hesitate to [give us a star](https://github.com/paradedb/paradedb).
+Ready to try ACID-compliant search? [Get started with ParadeDB](https://www.paradedb.com/docs/documentation/getting-started/install), and please don’t hesitate to [give us a star](https://github.com/paradedb/paradedb).

--- a/src/app/blog/elasticsearch-acid-test/index.mdx
+++ b/src/app/blog/elasticsearch-acid-test/index.mdx
@@ -98,4 +98,4 @@ ParadeDB removes that complexity. By extending Postgres with BM25-powered search
 
 _And you don’t have to replace what you already run. ParadeDB can serve as your primary database, or as a logical replica that delivers real-time search next to your existing Postgres server._
 
-Ready to try ACID-compliant search? [Get started with ParadeDB](https://docs.paradedb.com/documentation/getting-started/install), and please don’t hesitate to [give us a star](https://github.com/paradedb/paradedb).
+Ready to try ACID-compliant search? [Get started with ParadeDB](https://paradedb.com/docs/documentation/getting-started/install), and please don’t hesitate to [give us a star](https://github.com/paradedb/paradedb).

--- a/src/app/blog/etl-vs-logical-replication/index.mdx
+++ b/src/app/blog/etl-vs-logical-replication/index.mdx
@@ -126,7 +126,7 @@ hand the changes off to another system. In another camp are databases built on a
 
 For instance, [ParadeDB](https://www.paradedb.com) is an Elasticsearch alternative built on Postgres. It’s designed for Elastic-style search and analytical queries and is fully compatible with Postgres logical replication.
 
-If you’re curious how it works, check out our [architecture](https://paradedb.com/docs/welcome/architecture) — and don’t hesitate to give us a [star](https://github.com/paradedb/paradedb).
+If you’re curious how it works, check out our [architecture](https://www.paradedb.com/docs/welcome/architecture) — and don’t hesitate to give us a [star](https://github.com/paradedb/paradedb).
 
 <hr />
 

--- a/src/app/blog/etl-vs-logical-replication/index.mdx
+++ b/src/app/blog/etl-vs-logical-replication/index.mdx
@@ -126,7 +126,7 @@ hand the changes off to another system. In another camp are databases built on a
 
 For instance, [ParadeDB](https://www.paradedb.com) is an Elasticsearch alternative built on Postgres. It’s designed for Elastic-style search and analytical queries and is fully compatible with Postgres logical replication.
 
-If you’re curious how it works, check out our [architecture](https://docs.paradedb.com/welcome/architecture) — and don’t hesitate to give us a [star](https://github.com/paradedb/paradedb).
+If you’re curious how it works, check out our [architecture](https://paradedb.com/docs/welcome/architecture) — and don’t hesitate to give us a [star](https://github.com/paradedb/paradedb).
 
 <hr />
 

--- a/src/app/blog/faceting/index.mdx
+++ b/src/app/blog/faceting/index.mdx
@@ -85,7 +85,7 @@ When we set out to design the syntax for faceting, we had three goals:
 
 We experimented with a few approaches: full JSONB result sets, LATERAL subqueries, and a behind-the-scenes UNION. The one we kept coming back to was using PostgreSQL's window functions to express faceting instructions, passing a JSON DSL that mirrors the Elasticsearch aggregation API.
 
-That led us to a [new window function, `pdb.agg()`](https://paradedb.com/docs/documentation/aggregates/overview) (also usable in aggregate position, blog coming soon), which accepts JSONB that enables a range of aggregations. Most notably for faceting it supports [terms](https://paradedb.com/docs/documentation/aggregates/bucket/terms) (counting unique values), [histograms](https://paradedb.com/docs/documentation/aggregates/bucket/histogram) (bucketing unique values), and [date_histogram](https://paradedb.com/docs/documentation/aggregates/bucket/datehistogram) (bucketing timestamps).
+That led us to a [new window function, `pdb.agg()`](https://www.paradedb.com/docs/documentation/aggregates/overview) (also usable in aggregate position, blog coming soon), which accepts JSONB that enables a range of aggregations. Most notably for faceting it supports [terms](https://www.paradedb.com/docs/documentation/aggregates/bucket/terms) (counting unique values), [histograms](https://www.paradedb.com/docs/documentation/aggregates/bucket/histogram) (bucketing unique values), and [date_histogram](https://www.paradedb.com/docs/documentation/aggregates/bucket/datehistogram) (bucketing timestamps).
 
 Instead of complex CTEs and multiple queries, you get both search results and facet counts in a single, clean query:
 
@@ -285,10 +285,10 @@ Faceting is one of those features that looks simple on the surface, but is surpr
 
 The result is a simple SQL interface that gives you the best of both worlds: PostgreSQL's ACID guarantees and transactional semantics, combined with the performance and developer experience of modern search engines.
 
-Ready to try faceted search in your PostgreSQL database? [Get started with ParadeDB](https://paradedb.com/docs/documentation/getting-started/install) to see how faceting can transform your search experience, and please don’t hesitate to [give us a star](https://github.com/paradedb/paradedb).
+Ready to try faceted search in your PostgreSQL database? [Get started with ParadeDB](https://www.paradedb.com/docs/documentation/getting-started/install) to see how faceting can transform your search experience, and please don’t hesitate to [give us a star](https://github.com/paradedb/paradedb).
 
 ---
 
-[^1]: To create a ParadeDB search index, you would run: `CREATE INDEX ON hn_items USING BM25 (id, by, text, title, (url::pdb.literal), (type::pdb.literal), time, score) WITH (key_field=id);`. All non-text and `literal` tokenized text fields are available to use in faceting. Full documentation on index creation can be found under our [CREATE INDEX documentation](https://paradedb.com/docs/documentation/indexing/create-index).
+[^1]: To create a ParadeDB search index, you would run: `CREATE INDEX ON hn_items USING BM25 (id, by, text, title, (url::pdb.literal), (type::pdb.literal), time, score) WITH (key_field=id);`. All non-text and `literal` tokenized text fields are available to use in faceting. Full documentation on index creation can be found under our [CREATE INDEX documentation](https://www.paradedb.com/docs/documentation/indexing/create-index).
 
 [^2]: [MVCC (Multi-Version Concurrency Control)](https://www.postgresql.org/docs/current/mvcc.html) is PostgreSQL's mechanism for handling concurrent transactions by maintaining multiple versions of data when rows are modified. The built in [VACUUM](https://www.postgresql.org/docs/current/routine-vacuuming.html) asynchronously cleans up these old versions. Accessing rows includes visibility checks in both tables and indexes to ensure each transaction sees the correct version of data.

--- a/src/app/blog/faceting/index.mdx
+++ b/src/app/blog/faceting/index.mdx
@@ -85,7 +85,7 @@ When we set out to design the syntax for faceting, we had three goals:
 
 We experimented with a few approaches: full JSONB result sets, LATERAL subqueries, and a behind-the-scenes UNION. The one we kept coming back to was using PostgreSQL's window functions to express faceting instructions, passing a JSON DSL that mirrors the Elasticsearch aggregation API.
 
-That led us to a [new window function, `pdb.agg()`](https://docs.paradedb.com/documentation/aggregates/overview) (also usable in aggregate position, blog coming soon), which accepts JSONB that enables a range of aggregations. Most notably for faceting it supports [terms](https://docs.paradedb.com/documentation/aggregates/bucket/terms) (counting unique values), [histograms](https://docs.paradedb.com/documentation/aggregates/bucket/histogram) (bucketing unique values), and [date_histogram](https://docs.paradedb.com/documentation/aggregates/bucket/datehistogram) (bucketing timestamps).
+That led us to a [new window function, `pdb.agg()`](https://paradedb.com/docs/documentation/aggregates/overview) (also usable in aggregate position, blog coming soon), which accepts JSONB that enables a range of aggregations. Most notably for faceting it supports [terms](https://paradedb.com/docs/documentation/aggregates/bucket/terms) (counting unique values), [histograms](https://paradedb.com/docs/documentation/aggregates/bucket/histogram) (bucketing unique values), and [date_histogram](https://paradedb.com/docs/documentation/aggregates/bucket/datehistogram) (bucketing timestamps).
 
 Instead of complex CTEs and multiple queries, you get both search results and facet counts in a single, clean query:
 
@@ -285,10 +285,10 @@ Faceting is one of those features that looks simple on the surface, but is surpr
 
 The result is a simple SQL interface that gives you the best of both worlds: PostgreSQL's ACID guarantees and transactional semantics, combined with the performance and developer experience of modern search engines.
 
-Ready to try faceted search in your PostgreSQL database? [Get started with ParadeDB](https://docs.paradedb.com/documentation/getting-started/install) to see how faceting can transform your search experience, and please don’t hesitate to [give us a star](https://github.com/paradedb/paradedb).
+Ready to try faceted search in your PostgreSQL database? [Get started with ParadeDB](https://paradedb.com/docs/documentation/getting-started/install) to see how faceting can transform your search experience, and please don’t hesitate to [give us a star](https://github.com/paradedb/paradedb).
 
 ---
 
-[^1]: To create a ParadeDB search index, you would run: `CREATE INDEX ON hn_items USING BM25 (id, by, text, title, (url::pdb.literal), (type::pdb.literal), time, score) WITH (key_field=id);`. All non-text and `literal` tokenized text fields are available to use in faceting. Full documentation on index creation can be found under our [CREATE INDEX documentation](https://docs.paradedb.com/documentation/indexing/create-index).
+[^1]: To create a ParadeDB search index, you would run: `CREATE INDEX ON hn_items USING BM25 (id, by, text, title, (url::pdb.literal), (type::pdb.literal), time, score) WITH (key_field=id);`. All non-text and `literal` tokenized text fields are available to use in faceting. Full documentation on index creation can be found under our [CREATE INDEX documentation](https://paradedb.com/docs/documentation/indexing/create-index).
 
 [^2]: [MVCC (Multi-Version Concurrency Control)](https://www.postgresql.org/docs/current/mvcc.html) is PostgreSQL's mechanism for handling concurrent transactions by maintaining multiple versions of data when rows are modified. The built in [VACUUM](https://www.postgresql.org/docs/current/routine-vacuuming.html) asynchronously cleans up these old versions. Accessing rows includes visibility checks in both tables and indexes to ensure each transaction sees the correct version of data.

--- a/src/app/blog/hybrid-search-in-postgresql-the-missing-manual/index.mdx
+++ b/src/app/blog/hybrid-search-in-postgresql-the-missing-manual/index.mdx
@@ -52,7 +52,7 @@ Getting started with ParadeDB is straightforward. Once you have the extension in
 <Note>
   To add `pg_search` to your PostgreSQL instance (or to spin up a new instance
   with Docker) check out our [deployment
-  guides](https://paradedb.com/docs/deploy/overview).
+  guides](https://www.paradedb.com/docs/deploy/overview).
 </Note>
 
 ```sql
@@ -260,4 +260,4 @@ Hybrid search in PostgreSQL combines BM25's lexical precision with vector embedd
 
 The SQL-based approach means you can see exactly how rankings work, adjust weights intuitively, and add business logic as needed. No black-box algorithms or complex external systems to manage.
 
-Ready to get started? [Install ParadeDB](https://paradedb.com/docs/documentation/getting-started/install) and use RRF to combine BM25 with pgvector into hybrid search that actually works, and please don’t hesitate to [give us a star](https://github.com/paradedb/paradedb).
+Ready to get started? [Install ParadeDB](https://www.paradedb.com/docs/documentation/getting-started/install) and use RRF to combine BM25 with pgvector into hybrid search that actually works, and please don’t hesitate to [give us a star](https://github.com/paradedb/paradedb).

--- a/src/app/blog/hybrid-search-in-postgresql-the-missing-manual/index.mdx
+++ b/src/app/blog/hybrid-search-in-postgresql-the-missing-manual/index.mdx
@@ -52,7 +52,7 @@ Getting started with ParadeDB is straightforward. Once you have the extension in
 <Note>
   To add `pg_search` to your PostgreSQL instance (or to spin up a new instance
   with Docker) check out our [deployment
-  guides](https://docs.paradedb.com/deploy/overview).
+  guides](https://paradedb.com/docs/deploy/overview).
 </Note>
 
 ```sql
@@ -260,4 +260,4 @@ Hybrid search in PostgreSQL combines BM25's lexical precision with vector embedd
 
 The SQL-based approach means you can see exactly how rankings work, adjust weights intuitively, and add business logic as needed. No black-box algorithms or complex external systems to manage.
 
-Ready to get started? [Install ParadeDB](https://docs.paradedb.com/documentation/getting-started/install) and use RRF to combine BM25 with pgvector into hybrid search that actually works, and please don’t hesitate to [give us a star](https://github.com/paradedb/paradedb).
+Ready to get started? [Install ParadeDB](https://paradedb.com/docs/documentation/getting-started/install) and use RRF to combine BM25 with pgvector into hybrid search that actually works, and please don’t hesitate to [give us a star](https://github.com/paradedb/paradedb).

--- a/src/app/blog/increased-write-performance/index.mdx
+++ b/src/app/blog/increased-write-performance/index.mdx
@@ -154,4 +154,4 @@ Write performance is just one piece of the larger puzzle. ParadeDB already offer
 
 Our combination of Postgres's ACID guarantees with Elasticsearch-level search performance opens up exciting possibilities for application architectures. Instead of managing separate systems for transactions and search, developers can build on a single, consistent foundation.
 
-Ready to experience faster search indexing? [Get started with ParadeDB](https://paradedb.com/docs/documentation/getting-started/install) to see how write-optimized search can simplify your architecture, and please don’t hesitate to [give us a star](https://github.com/paradedb/paradedb).
+Ready to experience faster search indexing? [Get started with ParadeDB](https://www.paradedb.com/docs/documentation/getting-started/install) to see how write-optimized search can simplify your architecture, and please don’t hesitate to [give us a star](https://github.com/paradedb/paradedb).

--- a/src/app/blog/increased-write-performance/index.mdx
+++ b/src/app/blog/increased-write-performance/index.mdx
@@ -154,4 +154,4 @@ Write performance is just one piece of the larger puzzle. ParadeDB already offer
 
 Our combination of Postgres's ACID guarantees with Elasticsearch-level search performance opens up exciting possibilities for application architectures. Instead of managing separate systems for transactions and search, developers can build on a single, consistent foundation.
 
-Ready to experience faster search indexing? [Get started with ParadeDB](https://docs.paradedb.com/documentation/getting-started/install) to see how write-optimized search can simplify your architecture, and please don’t hesitate to [give us a star](https://github.com/paradedb/paradedb).
+Ready to experience faster search indexing? [Get started with ParadeDB](https://paradedb.com/docs/documentation/getting-started/install) to see how write-optimized search can simplify your architecture, and please don’t hesitate to [give us a star](https://github.com/paradedb/paradedb).

--- a/src/app/blog/lsm-trees-in-postgres/index.mdx
+++ b/src/app/blog/lsm-trees-in-postgres/index.mdx
@@ -129,7 +129,7 @@ Even with the help of `hot_standby_feedback`, standby servers are fundamentally 
 To achieve both physical and logical consistency, `pg_search` implements an atomically logged LSM tree, and to achieve logical consistency, we rely on `hot_standby_feedback`.
 
 This challenge was worth tackling because it enables the fastest possible search performance, without sacrificing consistency.
-To see it in action, check out [our documentation](https://docs.paradedb.com/welcome/introduction) or our [open source project](https://github.com/paradedb/paradedb)!
+To see it in action, check out [our documentation](https://paradedb.com/docs/welcome/introduction) or our [open source project](https://github.com/paradedb/paradedb)!
 
 <hr />
 

--- a/src/app/blog/lsm-trees-in-postgres/index.mdx
+++ b/src/app/blog/lsm-trees-in-postgres/index.mdx
@@ -129,7 +129,7 @@ Even with the help of `hot_standby_feedback`, standby servers are fundamentally 
 To achieve both physical and logical consistency, `pg_search` implements an atomically logged LSM tree, and to achieve logical consistency, we rely on `hot_standby_feedback`.
 
 This challenge was worth tackling because it enables the fastest possible search performance, without sacrificing consistency.
-To see it in action, check out [our documentation](https://paradedb.com/docs/welcome/introduction) or our [open source project](https://github.com/paradedb/paradedb)!
+To see it in action, check out [our documentation](https://www.paradedb.com/docs/welcome/introduction) or our [open source project](https://github.com/paradedb/paradedb)!
 
 <hr />
 

--- a/src/app/blog/optimizing-top-k/index.mdx
+++ b/src/app/blog/optimizing-top-k/index.mdx
@@ -272,7 +272,7 @@ LIMIT 10;
 
 <Note>
   `|||` is ParadeDB's [match
-  disjunction](https://paradedb.com/docs/documentation/full-text/match)
+  disjunction](https://www.paradedb.com/docs/documentation/full-text/match)
   operator.
 </Note>
 
@@ -292,7 +292,7 @@ ORDER BY severity, timestamp LIMIT 10;
 
 <Note>
   `===` is ParadeDB's [term
-  search](https://paradedb.com/docs/documentation/full-text/term) operator.
+  search](https://www.paradedb.com/docs/documentation/full-text/term) operator.
 </Note>
 
 This improvement was thanks to an upstream change in [Tantivy](https://github.com/quickwit-oss/tantivy), which changes how doc ID iterators are advanced when executing a boolean query.

--- a/src/app/blog/optimizing-top-k/index.mdx
+++ b/src/app/blog/optimizing-top-k/index.mdx
@@ -272,7 +272,7 @@ LIMIT 10;
 
 <Note>
   `|||` is ParadeDB's [match
-  disjunction](https://docs.paradedb.com/documentation/full-text/match)
+  disjunction](https://paradedb.com/docs/documentation/full-text/match)
   operator.
 </Note>
 
@@ -292,7 +292,7 @@ ORDER BY severity, timestamp LIMIT 10;
 
 <Note>
   `===` is ParadeDB's [term
-  search](https://docs.paradedb.com/documentation/full-text/term) operator.
+  search](https://paradedb.com/docs/documentation/full-text/term) operator.
 </Note>
 
 This improvement was thanks to an upstream change in [Tantivy](https://github.com/quickwit-oss/tantivy), which changes how doc ID iterators are advanced when executing a boolean query.

--- a/src/app/blog/paradedb-0-20-0/index.mdx
+++ b/src/app/blog/paradedb-0-20-0/index.mdx
@@ -23,7 +23,7 @@ Modern applications often require more than just search: they need [facets](/lea
 
 We have had fast aggregations on top of search queries for a while now, but it's not something we have talked about a lot. With `0.20.0` we have overhauled this feature, making [search faceting](/learn/search-concepts/faceting) (calculating counts for groups of records) a first-class citizen.
 
-Our search analytics are powered by a new [`pdb.agg()`](https://docs.paradedb.com/documentation/aggregates/overview) function can be used in two ways:
+Our search analytics are powered by a new [`pdb.agg()`](https://paradedb.com/docs/documentation/aggregates/overview) function can be used in two ways:
 
 - as an aggregate function, running a search query and providing aggregate results
 - as a window function, running a search query and providing aggregate results **alongside** the Top K search result
@@ -54,7 +54,7 @@ Our aggregations excel for large search result sets (millions of records), with 
   alt="Bar chart comparing faceting query time: ParadeDB Faceting takes 1013 milliseconds while Manual Faceting takes 11849 milliseconds, showing ParadeDB is over 11 times faster for search aggregations on 42 million results"
 />
 
-`pdb.agg()` can also be used with a [JSON argument](https://docs.paradedb.com/documentation/aggregates/overview) that closely mirrors the [Elasticsearch aggregations API](https://www.elastic.co/docs/explore-analyze/query-filter/aggregations), and in many cases is mapped to plain SQL constructs (like `COUNT(*)`).
+`pdb.agg()` can also be used with a [JSON argument](https://paradedb.com/docs/documentation/aggregates/overview) that closely mirrors the [Elasticsearch aggregations API](https://www.elastic.co/docs/explore-analyze/query-filter/aggregations), and in many cases is mapped to plain SQL constructs (like `COUNT(*)`).
 
 Let's have a look at some examples.
 
@@ -113,7 +113,7 @@ Behind the scenes, these queries use our [BM25 indexes](/learn/search-concepts/b
 
 ## v2 API: Less Magic, More Clarity
 
-None of these aggregation capabilities would matter if they were difficult to use, so alongside our performance work, we've also promoted our [V2 API](https://docs.paradedb.com/documentation/indexing/create-index) to the default experience, and the difference is immediately apparent with a much more intuitive SQL UX.
+None of these aggregation capabilities would matter if they were difficult to use, so alongside our performance work, we've also promoted our [V2 API](https://paradedb.com/docs/documentation/indexing/create-index) to the default experience, and the difference is immediately apparent with a much more intuitive SQL UX.
 
 One of the most significant advantages of the v2 API is that it eliminates the schema duplication that is present in most other search systems. With Elasticsearch, you must define your data structure twice: once in your application database and again in your Elasticsearch mapping:
 
@@ -163,7 +163,7 @@ LIMIT 5;
 (5 rows)
 ```
 
-Keep an eye out for another post showing off all the new v2 API features. For now, you can explore the full API reference in our [documentation](https://docs.paradedb.com/documentation/full-text/overview).
+Keep an eye out for another post showing off all the new v2 API features. For now, you can explore the full API reference in our [documentation](https://paradedb.com/docs/documentation/full-text/overview).
 
 ## Write Performance: Updates That Scale With You
 
@@ -213,4 +213,4 @@ Again, you can expect a follow up post with all the gory data-structure details.
 
 Version `0.20.0` strengthens ParadeDB as an alternative to Elasticsearch by adding fast search aggregations, a streamlined v2 API, and significantly improved write performance directly into PostgreSQL. For teams that value transactional consistency and operational simplicity, we provide a path to modern search capabilities without the complexity of managing separate systems.
 
-Ready to see search aggregations and the new API in action? [Try ParadeDB 0.20.0](https://docs.paradedb.com/documentation/getting-started/install) and experience what it's like when search, analytics, and transactions work together seamlessly.
+Ready to see search aggregations and the new API in action? [Try ParadeDB 0.20.0](https://paradedb.com/docs/documentation/getting-started/install) and experience what it's like when search, analytics, and transactions work together seamlessly.

--- a/src/app/blog/paradedb-0-20-0/index.mdx
+++ b/src/app/blog/paradedb-0-20-0/index.mdx
@@ -23,7 +23,7 @@ Modern applications often require more than just search: they need [facets](/lea
 
 We have had fast aggregations on top of search queries for a while now, but it's not something we have talked about a lot. With `0.20.0` we have overhauled this feature, making [search faceting](/learn/search-concepts/faceting) (calculating counts for groups of records) a first-class citizen.
 
-Our search analytics are powered by a new [`pdb.agg()`](https://paradedb.com/docs/documentation/aggregates/overview) function can be used in two ways:
+Our search analytics are powered by a new [`pdb.agg()`](https://www.paradedb.com/docs/documentation/aggregates/overview) function can be used in two ways:
 
 - as an aggregate function, running a search query and providing aggregate results
 - as a window function, running a search query and providing aggregate results **alongside** the Top K search result
@@ -54,7 +54,7 @@ Our aggregations excel for large search result sets (millions of records), with 
   alt="Bar chart comparing faceting query time: ParadeDB Faceting takes 1013 milliseconds while Manual Faceting takes 11849 milliseconds, showing ParadeDB is over 11 times faster for search aggregations on 42 million results"
 />
 
-`pdb.agg()` can also be used with a [JSON argument](https://paradedb.com/docs/documentation/aggregates/overview) that closely mirrors the [Elasticsearch aggregations API](https://www.elastic.co/docs/explore-analyze/query-filter/aggregations), and in many cases is mapped to plain SQL constructs (like `COUNT(*)`).
+`pdb.agg()` can also be used with a [JSON argument](https://www.paradedb.com/docs/documentation/aggregates/overview) that closely mirrors the [Elasticsearch aggregations API](https://www.elastic.co/docs/explore-analyze/query-filter/aggregations), and in many cases is mapped to plain SQL constructs (like `COUNT(*)`).
 
 Let's have a look at some examples.
 
@@ -113,7 +113,7 @@ Behind the scenes, these queries use our [BM25 indexes](/learn/search-concepts/b
 
 ## v2 API: Less Magic, More Clarity
 
-None of these aggregation capabilities would matter if they were difficult to use, so alongside our performance work, we've also promoted our [V2 API](https://paradedb.com/docs/documentation/indexing/create-index) to the default experience, and the difference is immediately apparent with a much more intuitive SQL UX.
+None of these aggregation capabilities would matter if they were difficult to use, so alongside our performance work, we've also promoted our [V2 API](https://www.paradedb.com/docs/documentation/indexing/create-index) to the default experience, and the difference is immediately apparent with a much more intuitive SQL UX.
 
 One of the most significant advantages of the v2 API is that it eliminates the schema duplication that is present in most other search systems. With Elasticsearch, you must define your data structure twice: once in your application database and again in your Elasticsearch mapping:
 
@@ -163,7 +163,7 @@ LIMIT 5;
 (5 rows)
 ```
 
-Keep an eye out for another post showing off all the new v2 API features. For now, you can explore the full API reference in our [documentation](https://paradedb.com/docs/documentation/full-text/overview).
+Keep an eye out for another post showing off all the new v2 API features. For now, you can explore the full API reference in our [documentation](https://www.paradedb.com/docs/documentation/full-text/overview).
 
 ## Write Performance: Updates That Scale With You
 
@@ -213,4 +213,4 @@ Again, you can expect a follow up post with all the gory data-structure details.
 
 Version `0.20.0` strengthens ParadeDB as an alternative to Elasticsearch by adding fast search aggregations, a streamlined v2 API, and significantly improved write performance directly into PostgreSQL. For teams that value transactional consistency and operational simplicity, we provide a path to modern search capabilities without the complexity of managing separate systems.
 
-Ready to see search aggregations and the new API in action? [Try ParadeDB 0.20.0](https://paradedb.com/docs/documentation/getting-started/install) and experience what it's like when search, analytics, and transactions work together seamlessly.
+Ready to see search aggregations and the new API in action? [Try ParadeDB 0.20.0](https://www.paradedb.com/docs/documentation/getting-started/install) and experience what it's like when search, analytics, and transactions work together seamlessly.

--- a/src/app/blog/railway/index.mdx
+++ b/src/app/blog/railway/index.mdx
@@ -71,4 +71,4 @@ LIMIT 5;
 
 ## What's Next
 
-To learn more about deploying ParadeDB on Railway, visit our [documentation](https://paradedb.com/docs/deploy/cloud-platforms/railway).
+To learn more about deploying ParadeDB on Railway, visit our [documentation](https://www.paradedb.com/docs/deploy/cloud-platforms/railway).

--- a/src/app/blog/railway/index.mdx
+++ b/src/app/blog/railway/index.mdx
@@ -71,4 +71,4 @@ LIMIT 5;
 
 ## What's Next
 
-To learn more about deploying ParadeDB on Railway, visit our [documentation](https://docs.paradedb.com/deploy/cloud-platforms/railway).
+To learn more about deploying ParadeDB on Railway, visit our [documentation](https://paradedb.com/docs/deploy/cloud-platforms/railway).

--- a/src/app/blog/rebrand/index.mdx
+++ b/src/app/blog/rebrand/index.mdx
@@ -8,7 +8,7 @@ import heroImage from "./images/hero.png";
 <AuthorSection metadata={blogMetadata} />
 <HeroImage src={heroImage} metadata={blogMetadata} />
 
-We're excited to unveil our rebranded [landing page](https://www.paradedb.com) and [docs](https://docs.paradedb.com/welcome/introduction). For the past year, the ParadeDB team has
+We're excited to unveil our rebranded [landing page](https://www.paradedb.com) and [docs](https://paradedb.com/docs/welcome/introduction). For the past year, the ParadeDB team has
 been focused on growing adoption of our open source project among the developer community. The old branding — dark mode with bright emerald as the primary color — reflected that.
 
 Today, we're reaching an inflection point where ParadeDB has been deployed across thousands of production environments on multi-terabyte clusters. Our revamped landing page

--- a/src/app/blog/rebrand/index.mdx
+++ b/src/app/blog/rebrand/index.mdx
@@ -8,7 +8,7 @@ import heroImage from "./images/hero.png";
 <AuthorSection metadata={blogMetadata} />
 <HeroImage src={heroImage} metadata={blogMetadata} />
 
-We're excited to unveil our rebranded [landing page](https://www.paradedb.com) and [docs](https://paradedb.com/docs/welcome/introduction). For the past year, the ParadeDB team has
+We're excited to unveil our rebranded [landing page](https://www.paradedb.com) and [docs](https://www.paradedb.com/docs/welcome/introduction). For the past year, the ParadeDB team has
 been focused on growing adoption of our open source project among the developer community. The old branding — dark mode with bright emerald as the primary color — reflected that.
 
 Today, we're reaching an inflection point where ParadeDB has been deployed across thousands of production environments on multi-terabyte clusters. Our revamped landing page

--- a/src/app/blog/render/index.mdx
+++ b/src/app/blog/render/index.mdx
@@ -75,4 +75,4 @@ LIMIT 5;
 
 ## What's Next
 
-To learn more about deploying ParadeDB on Render, visit our [documentation](https://docs.paradedb.com/deploy/cloud-platforms/render).
+To learn more about deploying ParadeDB on Render, visit our [documentation](https://paradedb.com/docs/deploy/cloud-platforms/render).

--- a/src/app/blog/render/index.mdx
+++ b/src/app/blog/render/index.mdx
@@ -75,4 +75,4 @@ LIMIT 5;
 
 ## What's Next
 
-To learn more about deploying ParadeDB on Render, visit our [documentation](https://paradedb.com/docs/deploy/cloud-platforms/render).
+To learn more about deploying ParadeDB on Render, visit our [documentation](https://www.paradedb.com/docs/deploy/cloud-platforms/render).

--- a/src/app/blog/v2api/index.mdx
+++ b/src/app/blog/v2api/index.mdx
@@ -32,7 +32,7 @@ In this post, we’ll walk through what’s new, and how the v2 API brings Parad
 
 The foundation of the v2 API is improved schema inference. When you create a search index, ParadeDB examines your existing table structure and automatically configures appropriate search behavior for each column type (rather than maintaining a separate JSON configuration blob). We believe your PostgreSQL schema should be the authoritative source of truth, so we built the system to work with what you already have.
 
-All the code examples in this post use the ParadeDB getting started demo table (which you can easily install by [following the SQL steps here](https://docs.paradedb.com/documentation/getting-started/install)).
+All the code examples in this post use the ParadeDB getting started demo table (which you can easily install by [following the SQL steps here](https://paradedb.com/docs/documentation/getting-started/install)).
 
 ```ini
 Table "public.mock_items"
@@ -48,7 +48,7 @@ Table "public.mock_items"
  weight_range          | int4range
 ```
 
-With the v2 API, creating a [BM25 search index](https://docs.paradedb.com/documentation/indexing/create-index) is straightforward:
+With the v2 API, creating a [BM25 search index](https://paradedb.com/docs/documentation/indexing/create-index) is straightforward:
 
 ```sql
 CREATE INDEX search_idx ON mock_items
@@ -69,7 +69,7 @@ This single statement creates a comprehensive search index without requiring you
 
 ## Understanding Tokenization
 
-One of the features we're most excited about in the v2 API is making [tokenization](https://docs.paradedb.com/documentation/tokenizers/overview) transparent and testable. We believe [understanding how text gets processed](/blog/when-tokenization-becomes-token) is crucial for building effective search experiences. The v2 API allows you to cast text to a tokenizer, then to a text array (`text[]`) to see exactly how it will be processed before you commit to an index configuration.
+One of the features we're most excited about in the v2 API is making [tokenization](https://paradedb.com/docs/documentation/tokenizers/overview) transparent and testable. We believe [understanding how text gets processed](/blog/when-tokenization-becomes-token) is crucial for building effective search experiences. The v2 API allows you to cast text to a tokenizer, then to a text array (`text[]`) to see exactly how it will be processed before you commit to an index configuration.
 
 ```sql
 SELECT 'Wireless noise-cancelling headphones'::pdb.unicode_words::text[];
@@ -82,18 +82,18 @@ SELECT 'Wireless noise-cancelling headphones'::pdb.unicode_words::text[];
 
 This transparency extends to different tokenization strategies, each optimized for specific use cases. Our default tokenizer is now `unicode_words`, but we have a many other options for slightly different use cases:
 
-- [**Unicode Words**](https://docs.paradedb.com/documentation/tokenizers/available-tokenizers/unicode): The unicode tokenizer splits text according to word boundaries defined by the [Unicode Standard Annex #29](https://www.unicode.org/reports/tr29/) rules.
-- [**Literal**](https://docs.paradedb.com/documentation/tokenizers/available-tokenizers/literal): indexes the text in its raw form, without any splitting or processing (and allows the field to be used for analytics)
-- [**Literal Normalized**](https://docs.paradedb.com/documentation/tokenizers/available-tokenizers/literal-normalized): like the literal tokenizer, but allows for token filters
-- [**Whitespace**](https://docs.paradedb.com/documentation/tokenizers/available-tokenizers/whitespace): splits on whitespace
-- [**Ngram**](https://docs.paradedb.com/documentation/tokenizers/available-tokenizers/ngrams): splits text into small chunks called grams, useful for partial matching
-- [**Simple**](https://docs.paradedb.com/documentation/tokenizers/available-tokenizers/simple): splits on any non-alphanumeric character
-- [**Regex Patterns**](https://docs.paradedb.com/documentation/tokenizers/available-tokenizers/regex): tokenizes text using a regular expression
-- [**Chinese Compatible**](https://docs.paradedb.com/documentation/tokenizers/available-tokenizers/chinese-compatible): a simple tokenizer for Chinese, Japanese, and Korean characters
-- [**Lindera**](https://docs.paradedb.com/documentation/tokenizers/available-tokenizers/lindera): uses prebuilt dictionaries to tokenize Chinese, Japanese, and Korean text
-- [**ICU**](https://docs.paradedb.com/documentation/tokenizers/available-tokenizers/icu): splits text according to the Unicode standard (often with more accuracy for Chinese, Japanese, and Korean text than `unicode_words`)
-- [**Jieba**](https://docs.paradedb.com/documentation/tokenizers/available-tokenizers/jieba): the most advanced Chinese tokenizer that uses both a dictionary and statistical models
-- [**Source Code**](https://docs.paradedb.com/documentation/tokenizers/available-tokenizers/source-code): tokenizes text that is actually code
+- [**Unicode Words**](https://paradedb.com/docs/documentation/tokenizers/available-tokenizers/unicode): The unicode tokenizer splits text according to word boundaries defined by the [Unicode Standard Annex #29](https://www.unicode.org/reports/tr29/) rules.
+- [**Literal**](https://paradedb.com/docs/documentation/tokenizers/available-tokenizers/literal): indexes the text in its raw form, without any splitting or processing (and allows the field to be used for analytics)
+- [**Literal Normalized**](https://paradedb.com/docs/documentation/tokenizers/available-tokenizers/literal-normalized): like the literal tokenizer, but allows for token filters
+- [**Whitespace**](https://paradedb.com/docs/documentation/tokenizers/available-tokenizers/whitespace): splits on whitespace
+- [**Ngram**](https://paradedb.com/docs/documentation/tokenizers/available-tokenizers/ngrams): splits text into small chunks called grams, useful for partial matching
+- [**Simple**](https://paradedb.com/docs/documentation/tokenizers/available-tokenizers/simple): splits on any non-alphanumeric character
+- [**Regex Patterns**](https://paradedb.com/docs/documentation/tokenizers/available-tokenizers/regex): tokenizes text using a regular expression
+- [**Chinese Compatible**](https://paradedb.com/docs/documentation/tokenizers/available-tokenizers/chinese-compatible): a simple tokenizer for Chinese, Japanese, and Korean characters
+- [**Lindera**](https://paradedb.com/docs/documentation/tokenizers/available-tokenizers/lindera): uses prebuilt dictionaries to tokenize Chinese, Japanese, and Korean text
+- [**ICU**](https://paradedb.com/docs/documentation/tokenizers/available-tokenizers/icu): splits text according to the Unicode standard (often with more accuracy for Chinese, Japanese, and Korean text than `unicode_words`)
+- [**Jieba**](https://paradedb.com/docs/documentation/tokenizers/available-tokenizers/jieba): the most advanced Chinese tokenizer that uses both a dictionary and statistical models
+- [**Source Code**](https://paradedb.com/docs/documentation/tokenizers/available-tokenizers/source-code): tokenizes text that is actually code
 
 You can test out other tokenizers using the same approach:
 
@@ -142,7 +142,7 @@ USING bm25 (
 
 This example shows how you can apply different tokenization strategies to the same field for different search patterns. The description field is tokenized both for standard word matching and partial matching (using an alias). This multi-tokenizer approach allows a single field to support multiple search behaviors without data duplication in the base table.
 
-[Token filters](https://docs.paradedb.com/documentation/token-filters/overview) provide another layer of search quality improvement. These filters process tokens after initial tokenization to improve search accuracy and relevance. The v2 API makes these filters configurable through declarative parameters inside the index column list rather than using JSON in an external blob.
+[Token filters](https://paradedb.com/docs/documentation/token-filters/overview) provide another layer of search quality improvement. These filters process tokens after initial tokenization to improve search accuracy and relevance. The v2 API makes these filters configurable through declarative parameters inside the index column list rather than using JSON in an external blob.
 
 ```sql
 CREATE INDEX search_idx ON mock_items
@@ -157,7 +157,7 @@ USING bm25 (
 ) WITH (key_field='id');
 ```
 
-The stemming filter reduces tokens to their root forms, allowing searches for "running" to match documents containing "runs" or "runner." ASCII folding removes diacritical marks, ensuring that searches work consistently across different character encodings. Stopword filtering removes common tokens that rarely contribute to search relevance. These filters work consistently at both index time and search time, ensuring that query processing matches the indexed data. We have [seven token filters](https://docs.paradedb.com/documentation/token-filters/overview) available today, with some others like synonyms on the way.
+The stemming filter reduces tokens to their root forms, allowing searches for "running" to match documents containing "runs" or "runner." ASCII folding removes diacritical marks, ensuring that searches work consistently across different character encodings. Stopword filtering removes common tokens that rarely contribute to search relevance. These filters work consistently at both index time and search time, ensuring that query processing matches the indexed data. We have [seven token filters](https://paradedb.com/docs/documentation/token-filters/overview) available today, with some others like synonyms on the way.
 
 ## Handling JSON Data
 
@@ -190,7 +190,7 @@ We designed this automatic handling because we believe complex data types should
 
 ## Search Operators
 
-The v2 API introduces a set of [SQL operators](https://docs.paradedb.com/documentation/full-text/overview) that make search query intent immediately clear. Instead of learning JSON query syntax or domain-specific languages, you use operators that communicate the type of matching you want to perform.
+The v2 API introduces a set of [SQL operators](https://paradedb.com/docs/documentation/full-text/overview) that make search query intent immediately clear. Instead of learning JSON query syntax or domain-specific languages, you use operators that communicate the type of matching you want to perform.
 
 ```sql
 -- Match disjunction: match any of these words (OR behavior)
@@ -224,7 +224,7 @@ Each operator has a specific semantic meaning:
 
 ## Proximity Search
 
-[Proximity search](https://docs.paradedb.com/documentation/full-text/proximity) is about finding terms that occur near each other, even when they aren't adjacent. This matters in domains like legal or compliance text, where meaning depends on concepts appearing together. For example, contract and obligation appearing within a few words of each other is very different from those words appearing in unrelated parts of a long document.
+[Proximity search](https://paradedb.com/docs/documentation/full-text/proximity) is about finding terms that occur near each other, even when they aren't adjacent. This matters in domains like legal or compliance text, where meaning depends on concepts appearing together. For example, contract and obligation appearing within a few words of each other is very different from those words appearing in unrelated parts of a long document.
 
 A simple OR search (`contract ||| obligation`) is too broad here — it returns documents where the terms appear anywhere, not necessarily together.
 
@@ -250,7 +250,7 @@ Proximity gives you a more meaningful match than OR (`|||`) but also a more flex
 
 ## Fuzzy Search
 
-[Fuzzy search](https://docs.paradedb.com/documentation/full-text/fuzzy) handles the reality that users make typos. Rather than returning no results for misspelled queries, fuzzy matching finds terms that are similar to what the user typed. This is essential for real-world search applications where perfect spelling can't be assumed.
+[Fuzzy search](https://paradedb.com/docs/documentation/full-text/fuzzy) handles the reality that users make typos. Rather than returning no results for misspelled queries, fuzzy matching finds terms that are similar to what the user typed. This is essential for real-world search applications where perfect spelling can't be assumed.
 
 Fuzzy search works by measuring edit distance — the number of single-character operations needed to transform one word into another. These operations include insertions ("shoe" → "shoes"), deletions ("running" → "running"), and transpositions ("shose" → "shoes").
 
@@ -272,7 +272,7 @@ Fuzzy search transforms failed searches into successful ones. A user searching f
 
 ## Relevance and Scoring
 
-Search without relevance ranking is simply filtered data. The v2 API provides comprehensive relevance [scoring capabilities](https://docs.paradedb.com/documentation/sorting/score) that allow you to understand and control how search results are ranked. This transparency is crucial for building search applications where result ordering significantly impacts user experience.
+Search without relevance ranking is simply filtered data. The v2 API provides comprehensive relevance [scoring capabilities](https://paradedb.com/docs/documentation/sorting/score) that allow you to understand and control how search results are ranked. This transparency is crucial for building search applications where result ordering significantly impacts user experience.
 
 ParadeDB uses the industry standard [BM25 algorithm](/learn/search-concepts/bm25) for relevance scoring, which [outperforms the Postgres built-in `tsvector`](/learn/search-in-postgresql/bm25) method. BM25 considers both term frequency within documents and term frequency across the entire corpus, ensuring that common terms have less impact on relevance than rare, distinctive terms.
 
@@ -299,7 +299,7 @@ Boosting allows you to emphasize certain terms or fields in relevance calculatio
 
 ## Search Highlighting
 
-Building effective search interfaces often requires showing users which parts of documents match their queries. [Highlighting](https://docs.paradedb.com/documentation/full-text/highlight) in ParadeDB is as simple as including the `pdb.snippet()` function call:
+Building effective search interfaces often requires showing users which parts of documents match their queries. [Highlighting](https://paradedb.com/docs/documentation/full-text/highlight) in ParadeDB is as simple as including the `pdb.snippet()` function call:
 
 ```sql
 -- Basic highlighting
@@ -335,7 +335,7 @@ The `pdb.snippets` function provides additional control over snippet generation,
 
 Modern search applications require more than just returning matching documents. Users expect [faceted navigation](/learn/search-concepts/faceting), result counts, statistical summaries, and other analytical insights that help them understand and refine their searches. The v2 API integrates analytics capabilities directly into the search infrastructure, allowing you to compute these insights efficiently in a single index pass.
 
-The [`pdb.agg()`](https://docs.paradedb.com/documentation/aggregates/overview) function can be used in two ways:
+The [`pdb.agg()`](https://paradedb.com/docs/documentation/aggregates/overview) function can be used in two ways:
 
 - As an aggregate function, running a search query and providing aggregate results
 - As a window function, running a search query and providing aggregate results **alongside** the Top K search results
@@ -397,7 +397,7 @@ We'll have a full post coming up on how we built this search aggregations system
 
 ## Advanced Query Types
 
-For applications with sophisticated search requirements, the v2 API includes several [advanced query capabilities](https://docs.paradedb.com/documentation/query-builder/overview) that address complex use cases without requiring external systems or custom development. These features integrate seamlessly with the core search functionality, allowing you to build powerful search experiences using familiar SQL syntax.
+For applications with sophisticated search requirements, the v2 API includes several [advanced query capabilities](https://paradedb.com/docs/documentation/query-builder/overview) that address complex use cases without requiring external systems or custom development. These features integrate seamlessly with the core search functionality, allowing you to build powerful search experiences using familiar SQL syntax.
 
 ```sql
 -- "More Like This" for recommendations like document with an ID of 3
@@ -421,16 +421,16 @@ WHERE id @@@ pdb.parse('
 
 The v2 API provides three advanced capabilities for sophisticated search requirements:
 
-- **[More Like This](https://docs.paradedb.com/documentation/query-builder/specialized/more-like-this)**: finds documents similar to a given document by analyzing term patterns and frequencies, creating representative terms and matching documents that contain those terms
-- **[Regex matching](https://docs.paradedb.com/documentation/query-builder/term/regex)**: provides power users with precise control over search patterns, enabling complex text matching that goes beyond simple term searching
-- **[Query parsing](https://docs.paradedb.com/documentation/query-builder/compound/query-parser)**: accepts raw user-provided query strings using [Tantivy's query language](https://docs.rs/tantivy/latest/tantivy/query/struct.QueryParser.html), supporting field-specific searches, boolean operators, and range queries with optional lenient mode for best-effort parsing
+- **[More Like This](https://paradedb.com/docs/documentation/query-builder/specialized/more-like-this)**: finds documents similar to a given document by analyzing term patterns and frequencies, creating representative terms and matching documents that contain those terms
+- **[Regex matching](https://paradedb.com/docs/documentation/query-builder/term/regex)**: provides power users with precise control over search patterns, enabling complex text matching that goes beyond simple term searching
+- **[Query parsing](https://paradedb.com/docs/documentation/query-builder/compound/query-parser)**: accepts raw user-provided query strings using [Tantivy's query language](https://docs.rs/tantivy/latest/tantivy/query/struct.QueryParser.html), supporting field-specific searches, boolean operators, and range queries with optional lenient mode for best-effort parsing
 
 ## Trying the v2 API
 
-This post covers the core features of the v2 API, but there's much more to explore. For the complete feature set, including advanced ranking options, custom analyzers, and specialized query types, check out the [full documentation](https://docs.paradedb.com/documentation/full-text/overview).
+This post covers the core features of the v2 API, but there's much more to explore. For the complete feature set, including advanced ranking options, custom analyzers, and specialized query types, check out the [full documentation](https://paradedb.com/docs/documentation/full-text/overview).
 
-All the examples in this post use ParadeDB's `mock_items` table, which you can install and try yourself following the [getting started guide](https://docs.paradedb.com/documentation/getting-started/install). Every query shown here works with the demo data, allowing you to explore the v2 API's capabilities hands-on.
+All the examples in this post use ParadeDB's `mock_items` table, which you can install and try yourself following the [getting started guide](https://paradedb.com/docs/documentation/getting-started/install). Every query shown here works with the demo data, allowing you to explore the v2 API's capabilities hands-on.
 
 The v2 API represents our vision for how search should work in SQL databases: powerful, flexible, and integrated rather than separate and complex. Because ParadeDB runs inside PostgreSQL, you get all the PostgreSQL guarantees you rely on: ACID transactions, backup and recovery, security, and the entire ecosystem of extensions and tools.
 
-[Get started with ParadeDB](https://docs.paradedb.com/documentation/getting-started/install) to see how the v2 API can simplify your search architecture while expanding your search capabilities, and please don’t hesitate to [give us a star](https://github.com/paradedb/paradedb).
+[Get started with ParadeDB](https://paradedb.com/docs/documentation/getting-started/install) to see how the v2 API can simplify your search architecture while expanding your search capabilities, and please don’t hesitate to [give us a star](https://github.com/paradedb/paradedb).

--- a/src/app/blog/v2api/index.mdx
+++ b/src/app/blog/v2api/index.mdx
@@ -32,7 +32,7 @@ In this post, we’ll walk through what’s new, and how the v2 API brings Parad
 
 The foundation of the v2 API is improved schema inference. When you create a search index, ParadeDB examines your existing table structure and automatically configures appropriate search behavior for each column type (rather than maintaining a separate JSON configuration blob). We believe your PostgreSQL schema should be the authoritative source of truth, so we built the system to work with what you already have.
 
-All the code examples in this post use the ParadeDB getting started demo table (which you can easily install by [following the SQL steps here](https://paradedb.com/docs/documentation/getting-started/install)).
+All the code examples in this post use the ParadeDB getting started demo table (which you can easily install by [following the SQL steps here](https://www.paradedb.com/docs/documentation/getting-started/install)).
 
 ```ini
 Table "public.mock_items"
@@ -48,7 +48,7 @@ Table "public.mock_items"
  weight_range          | int4range
 ```
 
-With the v2 API, creating a [BM25 search index](https://paradedb.com/docs/documentation/indexing/create-index) is straightforward:
+With the v2 API, creating a [BM25 search index](https://www.paradedb.com/docs/documentation/indexing/create-index) is straightforward:
 
 ```sql
 CREATE INDEX search_idx ON mock_items
@@ -69,7 +69,7 @@ This single statement creates a comprehensive search index without requiring you
 
 ## Understanding Tokenization
 
-One of the features we're most excited about in the v2 API is making [tokenization](https://paradedb.com/docs/documentation/tokenizers/overview) transparent and testable. We believe [understanding how text gets processed](/blog/when-tokenization-becomes-token) is crucial for building effective search experiences. The v2 API allows you to cast text to a tokenizer, then to a text array (`text[]`) to see exactly how it will be processed before you commit to an index configuration.
+One of the features we're most excited about in the v2 API is making [tokenization](https://www.paradedb.com/docs/documentation/tokenizers/overview) transparent and testable. We believe [understanding how text gets processed](/blog/when-tokenization-becomes-token) is crucial for building effective search experiences. The v2 API allows you to cast text to a tokenizer, then to a text array (`text[]`) to see exactly how it will be processed before you commit to an index configuration.
 
 ```sql
 SELECT 'Wireless noise-cancelling headphones'::pdb.unicode_words::text[];
@@ -82,18 +82,18 @@ SELECT 'Wireless noise-cancelling headphones'::pdb.unicode_words::text[];
 
 This transparency extends to different tokenization strategies, each optimized for specific use cases. Our default tokenizer is now `unicode_words`, but we have a many other options for slightly different use cases:
 
-- [**Unicode Words**](https://paradedb.com/docs/documentation/tokenizers/available-tokenizers/unicode): The unicode tokenizer splits text according to word boundaries defined by the [Unicode Standard Annex #29](https://www.unicode.org/reports/tr29/) rules.
-- [**Literal**](https://paradedb.com/docs/documentation/tokenizers/available-tokenizers/literal): indexes the text in its raw form, without any splitting or processing (and allows the field to be used for analytics)
-- [**Literal Normalized**](https://paradedb.com/docs/documentation/tokenizers/available-tokenizers/literal-normalized): like the literal tokenizer, but allows for token filters
-- [**Whitespace**](https://paradedb.com/docs/documentation/tokenizers/available-tokenizers/whitespace): splits on whitespace
-- [**Ngram**](https://paradedb.com/docs/documentation/tokenizers/available-tokenizers/ngrams): splits text into small chunks called grams, useful for partial matching
-- [**Simple**](https://paradedb.com/docs/documentation/tokenizers/available-tokenizers/simple): splits on any non-alphanumeric character
-- [**Regex Patterns**](https://paradedb.com/docs/documentation/tokenizers/available-tokenizers/regex): tokenizes text using a regular expression
-- [**Chinese Compatible**](https://paradedb.com/docs/documentation/tokenizers/available-tokenizers/chinese-compatible): a simple tokenizer for Chinese, Japanese, and Korean characters
-- [**Lindera**](https://paradedb.com/docs/documentation/tokenizers/available-tokenizers/lindera): uses prebuilt dictionaries to tokenize Chinese, Japanese, and Korean text
-- [**ICU**](https://paradedb.com/docs/documentation/tokenizers/available-tokenizers/icu): splits text according to the Unicode standard (often with more accuracy for Chinese, Japanese, and Korean text than `unicode_words`)
-- [**Jieba**](https://paradedb.com/docs/documentation/tokenizers/available-tokenizers/jieba): the most advanced Chinese tokenizer that uses both a dictionary and statistical models
-- [**Source Code**](https://paradedb.com/docs/documentation/tokenizers/available-tokenizers/source-code): tokenizes text that is actually code
+- [**Unicode Words**](https://www.paradedb.com/docs/documentation/tokenizers/available-tokenizers/unicode): The unicode tokenizer splits text according to word boundaries defined by the [Unicode Standard Annex #29](https://www.unicode.org/reports/tr29/) rules.
+- [**Literal**](https://www.paradedb.com/docs/documentation/tokenizers/available-tokenizers/literal): indexes the text in its raw form, without any splitting or processing (and allows the field to be used for analytics)
+- [**Literal Normalized**](https://www.paradedb.com/docs/documentation/tokenizers/available-tokenizers/literal-normalized): like the literal tokenizer, but allows for token filters
+- [**Whitespace**](https://www.paradedb.com/docs/documentation/tokenizers/available-tokenizers/whitespace): splits on whitespace
+- [**Ngram**](https://www.paradedb.com/docs/documentation/tokenizers/available-tokenizers/ngrams): splits text into small chunks called grams, useful for partial matching
+- [**Simple**](https://www.paradedb.com/docs/documentation/tokenizers/available-tokenizers/simple): splits on any non-alphanumeric character
+- [**Regex Patterns**](https://www.paradedb.com/docs/documentation/tokenizers/available-tokenizers/regex): tokenizes text using a regular expression
+- [**Chinese Compatible**](https://www.paradedb.com/docs/documentation/tokenizers/available-tokenizers/chinese-compatible): a simple tokenizer for Chinese, Japanese, and Korean characters
+- [**Lindera**](https://www.paradedb.com/docs/documentation/tokenizers/available-tokenizers/lindera): uses prebuilt dictionaries to tokenize Chinese, Japanese, and Korean text
+- [**ICU**](https://www.paradedb.com/docs/documentation/tokenizers/available-tokenizers/icu): splits text according to the Unicode standard (often with more accuracy for Chinese, Japanese, and Korean text than `unicode_words`)
+- [**Jieba**](https://www.paradedb.com/docs/documentation/tokenizers/available-tokenizers/jieba): the most advanced Chinese tokenizer that uses both a dictionary and statistical models
+- [**Source Code**](https://www.paradedb.com/docs/documentation/tokenizers/available-tokenizers/source-code): tokenizes text that is actually code
 
 You can test out other tokenizers using the same approach:
 
@@ -142,7 +142,7 @@ USING bm25 (
 
 This example shows how you can apply different tokenization strategies to the same field for different search patterns. The description field is tokenized both for standard word matching and partial matching (using an alias). This multi-tokenizer approach allows a single field to support multiple search behaviors without data duplication in the base table.
 
-[Token filters](https://paradedb.com/docs/documentation/token-filters/overview) provide another layer of search quality improvement. These filters process tokens after initial tokenization to improve search accuracy and relevance. The v2 API makes these filters configurable through declarative parameters inside the index column list rather than using JSON in an external blob.
+[Token filters](https://www.paradedb.com/docs/documentation/token-filters/overview) provide another layer of search quality improvement. These filters process tokens after initial tokenization to improve search accuracy and relevance. The v2 API makes these filters configurable through declarative parameters inside the index column list rather than using JSON in an external blob.
 
 ```sql
 CREATE INDEX search_idx ON mock_items
@@ -157,7 +157,7 @@ USING bm25 (
 ) WITH (key_field='id');
 ```
 
-The stemming filter reduces tokens to their root forms, allowing searches for "running" to match documents containing "runs" or "runner." ASCII folding removes diacritical marks, ensuring that searches work consistently across different character encodings. Stopword filtering removes common tokens that rarely contribute to search relevance. These filters work consistently at both index time and search time, ensuring that query processing matches the indexed data. We have [seven token filters](https://paradedb.com/docs/documentation/token-filters/overview) available today, with some others like synonyms on the way.
+The stemming filter reduces tokens to their root forms, allowing searches for "running" to match documents containing "runs" or "runner." ASCII folding removes diacritical marks, ensuring that searches work consistently across different character encodings. Stopword filtering removes common tokens that rarely contribute to search relevance. These filters work consistently at both index time and search time, ensuring that query processing matches the indexed data. We have [seven token filters](https://www.paradedb.com/docs/documentation/token-filters/overview) available today, with some others like synonyms on the way.
 
 ## Handling JSON Data
 
@@ -190,7 +190,7 @@ We designed this automatic handling because we believe complex data types should
 
 ## Search Operators
 
-The v2 API introduces a set of [SQL operators](https://paradedb.com/docs/documentation/full-text/overview) that make search query intent immediately clear. Instead of learning JSON query syntax or domain-specific languages, you use operators that communicate the type of matching you want to perform.
+The v2 API introduces a set of [SQL operators](https://www.paradedb.com/docs/documentation/full-text/overview) that make search query intent immediately clear. Instead of learning JSON query syntax or domain-specific languages, you use operators that communicate the type of matching you want to perform.
 
 ```sql
 -- Match disjunction: match any of these words (OR behavior)
@@ -224,7 +224,7 @@ Each operator has a specific semantic meaning:
 
 ## Proximity Search
 
-[Proximity search](https://paradedb.com/docs/documentation/full-text/proximity) is about finding terms that occur near each other, even when they aren't adjacent. This matters in domains like legal or compliance text, where meaning depends on concepts appearing together. For example, contract and obligation appearing within a few words of each other is very different from those words appearing in unrelated parts of a long document.
+[Proximity search](https://www.paradedb.com/docs/documentation/full-text/proximity) is about finding terms that occur near each other, even when they aren't adjacent. This matters in domains like legal or compliance text, where meaning depends on concepts appearing together. For example, contract and obligation appearing within a few words of each other is very different from those words appearing in unrelated parts of a long document.
 
 A simple OR search (`contract ||| obligation`) is too broad here — it returns documents where the terms appear anywhere, not necessarily together.
 
@@ -250,7 +250,7 @@ Proximity gives you a more meaningful match than OR (`|||`) but also a more flex
 
 ## Fuzzy Search
 
-[Fuzzy search](https://paradedb.com/docs/documentation/full-text/fuzzy) handles the reality that users make typos. Rather than returning no results for misspelled queries, fuzzy matching finds terms that are similar to what the user typed. This is essential for real-world search applications where perfect spelling can't be assumed.
+[Fuzzy search](https://www.paradedb.com/docs/documentation/full-text/fuzzy) handles the reality that users make typos. Rather than returning no results for misspelled queries, fuzzy matching finds terms that are similar to what the user typed. This is essential for real-world search applications where perfect spelling can't be assumed.
 
 Fuzzy search works by measuring edit distance — the number of single-character operations needed to transform one word into another. These operations include insertions ("shoe" → "shoes"), deletions ("running" → "running"), and transpositions ("shose" → "shoes").
 
@@ -272,7 +272,7 @@ Fuzzy search transforms failed searches into successful ones. A user searching f
 
 ## Relevance and Scoring
 
-Search without relevance ranking is simply filtered data. The v2 API provides comprehensive relevance [scoring capabilities](https://paradedb.com/docs/documentation/sorting/score) that allow you to understand and control how search results are ranked. This transparency is crucial for building search applications where result ordering significantly impacts user experience.
+Search without relevance ranking is simply filtered data. The v2 API provides comprehensive relevance [scoring capabilities](https://www.paradedb.com/docs/documentation/sorting/score) that allow you to understand and control how search results are ranked. This transparency is crucial for building search applications where result ordering significantly impacts user experience.
 
 ParadeDB uses the industry standard [BM25 algorithm](/learn/search-concepts/bm25) for relevance scoring, which [outperforms the Postgres built-in `tsvector`](/learn/search-in-postgresql/bm25) method. BM25 considers both term frequency within documents and term frequency across the entire corpus, ensuring that common terms have less impact on relevance than rare, distinctive terms.
 
@@ -299,7 +299,7 @@ Boosting allows you to emphasize certain terms or fields in relevance calculatio
 
 ## Search Highlighting
 
-Building effective search interfaces often requires showing users which parts of documents match their queries. [Highlighting](https://paradedb.com/docs/documentation/full-text/highlight) in ParadeDB is as simple as including the `pdb.snippet()` function call:
+Building effective search interfaces often requires showing users which parts of documents match their queries. [Highlighting](https://www.paradedb.com/docs/documentation/full-text/highlight) in ParadeDB is as simple as including the `pdb.snippet()` function call:
 
 ```sql
 -- Basic highlighting
@@ -335,7 +335,7 @@ The `pdb.snippets` function provides additional control over snippet generation,
 
 Modern search applications require more than just returning matching documents. Users expect [faceted navigation](/learn/search-concepts/faceting), result counts, statistical summaries, and other analytical insights that help them understand and refine their searches. The v2 API integrates analytics capabilities directly into the search infrastructure, allowing you to compute these insights efficiently in a single index pass.
 
-The [`pdb.agg()`](https://paradedb.com/docs/documentation/aggregates/overview) function can be used in two ways:
+The [`pdb.agg()`](https://www.paradedb.com/docs/documentation/aggregates/overview) function can be used in two ways:
 
 - As an aggregate function, running a search query and providing aggregate results
 - As a window function, running a search query and providing aggregate results **alongside** the Top K search results
@@ -397,7 +397,7 @@ We'll have a full post coming up on how we built this search aggregations system
 
 ## Advanced Query Types
 
-For applications with sophisticated search requirements, the v2 API includes several [advanced query capabilities](https://paradedb.com/docs/documentation/query-builder/overview) that address complex use cases without requiring external systems or custom development. These features integrate seamlessly with the core search functionality, allowing you to build powerful search experiences using familiar SQL syntax.
+For applications with sophisticated search requirements, the v2 API includes several [advanced query capabilities](https://www.paradedb.com/docs/documentation/query-builder/overview) that address complex use cases without requiring external systems or custom development. These features integrate seamlessly with the core search functionality, allowing you to build powerful search experiences using familiar SQL syntax.
 
 ```sql
 -- "More Like This" for recommendations like document with an ID of 3
@@ -421,16 +421,16 @@ WHERE id @@@ pdb.parse('
 
 The v2 API provides three advanced capabilities for sophisticated search requirements:
 
-- **[More Like This](https://paradedb.com/docs/documentation/query-builder/specialized/more-like-this)**: finds documents similar to a given document by analyzing term patterns and frequencies, creating representative terms and matching documents that contain those terms
-- **[Regex matching](https://paradedb.com/docs/documentation/query-builder/term/regex)**: provides power users with precise control over search patterns, enabling complex text matching that goes beyond simple term searching
-- **[Query parsing](https://paradedb.com/docs/documentation/query-builder/compound/query-parser)**: accepts raw user-provided query strings using [Tantivy's query language](https://docs.rs/tantivy/latest/tantivy/query/struct.QueryParser.html), supporting field-specific searches, boolean operators, and range queries with optional lenient mode for best-effort parsing
+- **[More Like This](https://www.paradedb.com/docs/documentation/query-builder/specialized/more-like-this)**: finds documents similar to a given document by analyzing term patterns and frequencies, creating representative terms and matching documents that contain those terms
+- **[Regex matching](https://www.paradedb.com/docs/documentation/query-builder/term/regex)**: provides power users with precise control over search patterns, enabling complex text matching that goes beyond simple term searching
+- **[Query parsing](https://www.paradedb.com/docs/documentation/query-builder/compound/query-parser)**: accepts raw user-provided query strings using [Tantivy's query language](https://docs.rs/tantivy/latest/tantivy/query/struct.QueryParser.html), supporting field-specific searches, boolean operators, and range queries with optional lenient mode for best-effort parsing
 
 ## Trying the v2 API
 
-This post covers the core features of the v2 API, but there's much more to explore. For the complete feature set, including advanced ranking options, custom analyzers, and specialized query types, check out the [full documentation](https://paradedb.com/docs/documentation/full-text/overview).
+This post covers the core features of the v2 API, but there's much more to explore. For the complete feature set, including advanced ranking options, custom analyzers, and specialized query types, check out the [full documentation](https://www.paradedb.com/docs/documentation/full-text/overview).
 
-All the examples in this post use ParadeDB's `mock_items` table, which you can install and try yourself following the [getting started guide](https://paradedb.com/docs/documentation/getting-started/install). Every query shown here works with the demo data, allowing you to explore the v2 API's capabilities hands-on.
+All the examples in this post use ParadeDB's `mock_items` table, which you can install and try yourself following the [getting started guide](https://www.paradedb.com/docs/documentation/getting-started/install). Every query shown here works with the demo data, allowing you to explore the v2 API's capabilities hands-on.
 
 The v2 API represents our vision for how search should work in SQL databases: powerful, flexible, and integrated rather than separate and complex. Because ParadeDB runs inside PostgreSQL, you get all the PostgreSQL guarantees you rely on: ACID transactions, backup and recovery, security, and the entire ecosystem of extensions and tools.
 
-[Get started with ParadeDB](https://paradedb.com/docs/documentation/getting-started/install) to see how the v2 API can simplify your search architecture while expanding your search capabilities, and please don’t hesitate to [give us a star](https://github.com/paradedb/paradedb).
+[Get started with ParadeDB](https://www.paradedb.com/docs/documentation/getting-started/install) to see how the v2 API can simplify your search architecture while expanding your search capabilities, and please don’t hesitate to [give us a star](https://github.com/paradedb/paradedb).

--- a/src/app/blog/when-tokenization-becomes-token/index.mdx
+++ b/src/app/blog/when-tokenization-becomes-token/index.mdx
@@ -115,7 +115,7 @@ Tokenization doesn’t get the glory. Nobody brags about their stopword filter a
 
 Every search engine invests heavily here because everything else (scoring, ranking, relevance) depends on getting tokens right. It’s not glamorous, but it’s precise, and when you get this part right, everything else in search works better.
 
-[Get started with ParadeDB](https://docs.paradedb.com/documentation/getting-started/install) to see how modern search databases handle tokenization for you, and please don’t hesitate to [give us a star](https://github.com/paradedb/paradedb).
+[Get started with ParadeDB](https://paradedb.com/docs/documentation/getting-started/install) to see how modern search databases handle tokenization for you, and please don’t hesitate to [give us a star](https://github.com/paradedb/paradedb).
 
 ---
 

--- a/src/app/blog/when-tokenization-becomes-token/index.mdx
+++ b/src/app/blog/when-tokenization-becomes-token/index.mdx
@@ -115,7 +115,7 @@ Tokenization doesn’t get the glory. Nobody brags about their stopword filter a
 
 Every search engine invests heavily here because everything else (scoring, ranking, relevance) depends on getting tokens right. It’s not glamorous, but it’s precise, and when you get this part right, everything else in search works better.
 
-[Get started with ParadeDB](https://paradedb.com/docs/documentation/getting-started/install) to see how modern search databases handle tokenization for you, and please don’t hesitate to [give us a star](https://github.com/paradedb/paradedb).
+[Get started with ParadeDB](https://www.paradedb.com/docs/documentation/getting-started/install) to see how modern search databases handle tokenization for you, and please don’t hesitate to [give us a star](https://github.com/paradedb/paradedb).
 
 ---
 

--- a/src/app/learn/search-concepts/full-text-search/index.mdx
+++ b/src/app/learn/search-concepts/full-text-search/index.mdx
@@ -59,7 +59,7 @@ Consider indexing two simple documents:
 | 1      | "PostgreSQL supports search" |
 | 2      | "Search engines use indexes" |
 
-After tokenization and normalization, the inverted index looks like this (using an [english language tokenizer](https://docs.paradedb.com/documentation/tokenizers/available-tokenizers/simple) with no stemming):
+After tokenization and normalization, the inverted index looks like this (using an [english language tokenizer](https://paradedb.com/docs/documentation/tokenizers/available-tokenizers/simple) with no stemming):
 
 | **Term**   | **Postings List**                          |
 | ---------- | ------------------------------------------ |

--- a/src/app/learn/search-concepts/full-text-search/index.mdx
+++ b/src/app/learn/search-concepts/full-text-search/index.mdx
@@ -59,7 +59,7 @@ Consider indexing two simple documents:
 | 1      | "PostgreSQL supports search" |
 | 2      | "Search engines use indexes" |
 
-After tokenization and normalization, the inverted index looks like this (using an [english language tokenizer](https://paradedb.com/docs/documentation/tokenizers/available-tokenizers/simple) with no stemming):
+After tokenization and normalization, the inverted index looks like this (using an [english language tokenizer](https://www.paradedb.com/docs/documentation/tokenizers/available-tokenizers/simple) with no stemming):
 
 | **Term**   | **Postings List**                          |
 | ---------- | ------------------------------------------ |

--- a/src/app/learn/search-in-postgresql/bm25/index.mdx
+++ b/src/app/learn/search-in-postgresql/bm25/index.mdx
@@ -79,7 +79,7 @@ USING bm25 (id, description, category, rating)
 WITH (key_field='id');
 ```
 
-The BM25 index is laid out on disk as an [**LSM tree**](https://docs.paradedb.com/welcome/architecture#lsm-tree), where each segment in the tree consists of both an inverted index and columnar index. The inverted and columnar indexes optimize for fast reads, while the LSM tree optimizes for high-frequency writes.
+The BM25 index is laid out on disk as an [**LSM tree**](https://paradedb.com/docs/welcome/architecture#lsm-tree), where each segment in the tree consists of both an inverted index and columnar index. The inverted and columnar indexes optimize for fast reads, while the LSM tree optimizes for high-frequency writes.
 
 ParadeDB users can access full-text search and BM25 relevancy ranking by using custom operators and functions. For example, a search using match disjunction (find all documents which match one or more terms), ordering by BM25 scores, and then returning the top 5 would look like this:
 

--- a/src/app/learn/search-in-postgresql/bm25/index.mdx
+++ b/src/app/learn/search-in-postgresql/bm25/index.mdx
@@ -79,7 +79,7 @@ USING bm25 (id, description, category, rating)
 WITH (key_field='id');
 ```
 
-The BM25 index is laid out on disk as an [**LSM tree**](https://paradedb.com/docs/welcome/architecture#lsm-tree), where each segment in the tree consists of both an inverted index and columnar index. The inverted and columnar indexes optimize for fast reads, while the LSM tree optimizes for high-frequency writes.
+The BM25 index is laid out on disk as an [**LSM tree**](https://www.paradedb.com/docs/welcome/architecture#lsm-tree), where each segment in the tree consists of both an inverted index and columnar index. The inverted and columnar indexes optimize for fast reads, while the LSM tree optimizes for high-frequency writes.
 
 ParadeDB users can access full-text search and BM25 relevancy ranking by using custom operators and functions. For example, a search using match disjunction (find all documents which match one or more terms), ordering by BM25 scores, and then returning the top 5 would look like this:
 

--- a/src/app/vs/postgresql/page.tsx
+++ b/src/app/vs/postgresql/page.tsx
@@ -29,7 +29,7 @@ function A({ href, children }: { href: string; children: ReactNode }) {
 }
 
 const PG = "https://www.postgresql.org/docs/current";
-const DOCS = "https://paradedb.com/docs";
+const DOCS = "https://www.paradedb.com/docs";
 
 export const metadata: Metadata = {
   title: "Comparing ParadeDB and Postgres Full-Text Search",

--- a/src/app/vs/postgresql/page.tsx
+++ b/src/app/vs/postgresql/page.tsx
@@ -29,7 +29,7 @@ function A({ href, children }: { href: string; children: ReactNode }) {
 }
 
 const PG = "https://www.postgresql.org/docs/current";
-const DOCS = "https://docs.paradedb.com";
+const DOCS = "https://paradedb.com/docs";
 
 export const metadata: Metadata = {
   title: "Comparing ParadeDB and Postgres Full-Text Search",

--- a/src/components/ui/AgentReady.tsx
+++ b/src/components/ui/AgentReady.tsx
@@ -212,7 +212,7 @@ const CloudPlatforms = [
   {
     name: "DigitalOcean",
     className: "text-[#0080ff]",
-    deployUrl: "https://docs.paradedb.com/deploy/cloud-platforms/digitalocean",
+    deployUrl: "https://paradedb.com/docs/deploy/cloud-platforms/digitalocean",
     icon: (
       <svg
         xmlns="http://www.w3.org/2000/svg"
@@ -229,7 +229,7 @@ const CloudPlatforms = [
   {
     name: "Fly.io",
     className: "text-[#24175b] dark:text-[#9b8bdb]",
-    deployUrl: "https://docs.paradedb.com/deploy/cloud-platforms/fly",
+    deployUrl: "https://paradedb.com/docs/deploy/cloud-platforms/fly",
     icon: (
       <svg
         viewBox="0 0 24 24"
@@ -244,7 +244,7 @@ const CloudPlatforms = [
   {
     name: "Dokku",
     className: "",
-    deployUrl: "https://docs.paradedb.com/deploy/cloud-platforms/dokku",
+    deployUrl: "https://paradedb.com/docs/deploy/cloud-platforms/dokku",
     icon: (
       <svg
         viewBox="0 0 89 62"
@@ -531,7 +531,7 @@ export default function AgentReady() {
                             Devin, Gemini, and more.
                           </p>
                           <Link
-                            href="https://docs.paradedb.com/documentation/getting-started/ai-agents"
+                            href="https://paradedb.com/docs/documentation/getting-started/ai-agents"
                             target="_blank"
                             className="mt-auto flex w-fit items-center gap-1 text-sm font-semibold text-indigo-600 dark:text-indigo-400 hover:text-indigo-700 dark:hover:text-indigo-300"
                           >
@@ -594,7 +594,7 @@ export default function AgentReady() {
                           </p>
                           <div className="mt-auto flex flex-col gap-2">
                             <Link
-                              href="https://docs.paradedb.com/documentation/getting-started/environment"
+                              href="https://paradedb.com/docs/documentation/getting-started/environment"
                               target="_blank"
                               className="flex w-fit items-center gap-1 text-sm font-semibold text-indigo-600 dark:text-indigo-400 hover:text-indigo-700 dark:hover:text-indigo-300"
                             >

--- a/src/components/ui/AgentReady.tsx
+++ b/src/components/ui/AgentReady.tsx
@@ -212,7 +212,8 @@ const CloudPlatforms = [
   {
     name: "DigitalOcean",
     className: "text-[#0080ff]",
-    deployUrl: "https://paradedb.com/docs/deploy/cloud-platforms/digitalocean",
+    deployUrl:
+      "https://www.paradedb.com/docs/deploy/cloud-platforms/digitalocean",
     icon: (
       <svg
         xmlns="http://www.w3.org/2000/svg"
@@ -229,7 +230,7 @@ const CloudPlatforms = [
   {
     name: "Fly.io",
     className: "text-[#24175b] dark:text-[#9b8bdb]",
-    deployUrl: "https://paradedb.com/docs/deploy/cloud-platforms/fly",
+    deployUrl: "https://www.paradedb.com/docs/deploy/cloud-platforms/fly",
     icon: (
       <svg
         viewBox="0 0 24 24"
@@ -244,7 +245,7 @@ const CloudPlatforms = [
   {
     name: "Dokku",
     className: "",
-    deployUrl: "https://paradedb.com/docs/deploy/cloud-platforms/dokku",
+    deployUrl: "https://www.paradedb.com/docs/deploy/cloud-platforms/dokku",
     icon: (
       <svg
         viewBox="0 0 89 62"
@@ -531,7 +532,7 @@ export default function AgentReady() {
                             Devin, Gemini, and more.
                           </p>
                           <Link
-                            href="https://paradedb.com/docs/documentation/getting-started/ai-agents"
+                            href="https://www.paradedb.com/docs/documentation/getting-started/ai-agents"
                             target="_blank"
                             className="mt-auto flex w-fit items-center gap-1 text-sm font-semibold text-indigo-600 dark:text-indigo-400 hover:text-indigo-700 dark:hover:text-indigo-300"
                           >
@@ -594,7 +595,7 @@ export default function AgentReady() {
                           </p>
                           <div className="mt-auto flex flex-col gap-2">
                             <Link
-                              href="https://paradedb.com/docs/documentation/getting-started/environment"
+                              href="https://www.paradedb.com/docs/documentation/getting-started/environment"
                               target="_blank"
                               className="flex w-fit items-center gap-1 text-sm font-semibold text-indigo-600 dark:text-indigo-400 hover:text-indigo-700 dark:hover:text-indigo-300"
                             >

--- a/src/lib/links.ts
+++ b/src/lib/links.ts
@@ -3,16 +3,16 @@ export const company = {
 };
 
 export const documentation = {
-  BASE: "https://docs.paradedb.com/welcome/introduction",
+  BASE: "https://paradedb.com/docs/welcome/introduction",
   GETTING_STARTED:
-    "https://docs.paradedb.com/documentation/getting-started/install",
-  SEARCH: "https://docs.paradedb.com/documentation/full-text/overview",
-  ANALYTICS: "https://docs.paradedb.com/documentation/aggregates/overview",
+    "https://paradedb.com/docs/documentation/getting-started/install",
+  SEARCH: "https://paradedb.com/docs/documentation/full-text/overview",
+  ANALYTICS: "https://paradedb.com/docs/documentation/aggregates/overview",
   REPLICATION:
-    "https://docs.paradedb.com/deploy/logical-replication/getting-started",
-  INGEST: "https://docs.paradedb.com/deploy/third-party-extensions",
-  DEPLOY_EXTENSION: "https://docs.paradedb.com/deploy/self-hosted/extension",
-  CHANGELOG: "https://docs.paradedb.com/changelog",
+    "https://paradedb.com/docs/deploy/logical-replication/getting-started",
+  INGEST: "https://paradedb.com/docs/deploy/third-party-extensions",
+  DEPLOY_EXTENSION: "https://paradedb.com/docs/deploy/self-hosted/extension",
+  CHANGELOG: "https://paradedb.com/docs/changelog",
 };
 
 export const legal = {

--- a/src/lib/links.ts
+++ b/src/lib/links.ts
@@ -3,16 +3,17 @@ export const company = {
 };
 
 export const documentation = {
-  BASE: "https://paradedb.com/docs/welcome/introduction",
+  BASE: "https://www.paradedb.com/docs/welcome/introduction",
   GETTING_STARTED:
-    "https://paradedb.com/docs/documentation/getting-started/install",
-  SEARCH: "https://paradedb.com/docs/documentation/full-text/overview",
-  ANALYTICS: "https://paradedb.com/docs/documentation/aggregates/overview",
+    "https://www.paradedb.com/docs/documentation/getting-started/install",
+  SEARCH: "https://www.paradedb.com/docs/documentation/full-text/overview",
+  ANALYTICS: "https://www.paradedb.com/docs/documentation/aggregates/overview",
   REPLICATION:
-    "https://paradedb.com/docs/deploy/logical-replication/getting-started",
-  INGEST: "https://paradedb.com/docs/deploy/third-party-extensions",
-  DEPLOY_EXTENSION: "https://paradedb.com/docs/deploy/self-hosted/extension",
-  CHANGELOG: "https://paradedb.com/docs/changelog",
+    "https://www.paradedb.com/docs/deploy/logical-replication/getting-started",
+  INGEST: "https://www.paradedb.com/docs/deploy/third-party-extensions",
+  DEPLOY_EXTENSION:
+    "https://www.paradedb.com/docs/deploy/self-hosted/extension",
+  CHANGELOG: "https://www.paradedb.com/docs/changelog",
 };
 
 export const legal = {

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -37,7 +37,7 @@ const MARKDOWN_NOT_FOUND = `# 404 Not Found
 No page exists at this URL.
 
 - [ParadeDB content index](https://www.paradedb.com/llms.txt)
-- [Documentation](https://paradedb.com/docs/welcome/introduction)
+- [Documentation](https://www.paradedb.com/docs/welcome/introduction)
 - [Sitemap](https://www.paradedb.com/sitemap.xml)
 `;
 

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -37,7 +37,7 @@ const MARKDOWN_NOT_FOUND = `# 404 Not Found
 No page exists at this URL.
 
 - [ParadeDB content index](https://www.paradedb.com/llms.txt)
-- [Documentation](https://docs.paradedb.com/welcome/introduction)
+- [Documentation](https://paradedb.com/docs/welcome/introduction)
 - [Sitemap](https://www.paradedb.com/sitemap.xml)
 `;
 


### PR DESCRIPTION
## Summary

- update ParadeDB documentation links from docs.paradedb.com to paradedb.com/docs
- preserve every existing documentation path and anchor

## Verification

- confirmed representative replacement URLs resolve successfully
- git diff --check
- verified no obsolete documentation URLs remain, excluding the intentional legacy-host redirect rules in the website repository