### PR TITLE
fix: use ParadeDB index terminology

### DIFF
--- a/public/benchmarks/topk_10_hn_text.json
+++ b/public/benchmarks/topk_10_hn_text.json
@@ -21,7 +21,7 @@
         "paradedb": {
           "paradedb.global_mutable_segment_rows": "-1"
         },
-        "post_script": "-- ParadeDB post-load: Create BM25 index\nCREATE INDEX hn_items_idx ON hn_items\nUSING bm25 (id, title, text, (by::pdb.literal), (type::pdb.literal), (url::pdb.literal), score, time)\nWITH (key_field='id');\n\nVACUUM ANALYZE hn_items;\n",
+        "post_script": "-- ParadeDB post-load: Create ParadeDB index\nCREATE INDEX hn_items_idx ON hn_items\nUSING paradedb (id, title, text, (by::pdb.literal), (type::pdb.literal), (url::pdb.literal), score, time)\nWITH (key_field='id');\n\nVACUUM ANALYZE hn_items;\n",
         "postgresql": {
           "effective_cache_size": "5242888kB",
           "jit": "off",

--- a/src/app/blog/benchmarker-iteration/index.mdx
+++ b/src/app/blog/benchmarker-iteration/index.mdx
@@ -43,7 +43,7 @@ Both backends run in their own Docker containers, each with four cores and eight
 
 The data is a cut-down slice[^2] of the Hacker News archive: one million rows in a single `hn_items` table, keeping only the `id` and `text` of each post.
 
-The comparison is [ParadeDB](https://github.com/paradedb/paradedb)'s BM25 index against Postgres' built-in tsvector datatype and a GIN index (often referred to as [Postgres full-text search](https://www.postgresql.org/docs/current/textsearch.html)). These are different ranking models over different index implementations, but both are ways developers can run TopK relevance search inside Postgres.
+The comparison is a [ParadeDB](https://github.com/paradedb/paradedb) index using BM25 ranking against Postgres' built-in tsvector datatype and a GIN index (often referred to as [Postgres full-text search](https://www.postgresql.org/docs/current/textsearch.html)). These are different ranking models over different index implementations, but both are ways developers can run TopK relevance search inside Postgres.
 
 ParadeDB indexes `text` directly with [BM25](https://www.paradedb.com/learn/search-concepts/bm25). Postgres pre-tokenizes `text` into a stored generated `tsv` column and indexes that value with GIN[^3]. Both are configured for English text processing, and both answer the same query shape using their native syntax:
 

--- a/src/app/blog/faceting/index.mdx
+++ b/src/app/blog/faceting/index.mdx
@@ -289,6 +289,6 @@ Ready to try faceted search in your PostgreSQL database? [Get started with Parad
 
 ---
 
-[^1]: To create a ParadeDB search index, you would run: `CREATE INDEX ON hn_items USING BM25 (id, by, text, title, (url::pdb.literal), (type::pdb.literal), time, score) WITH (key_field=id);`. All non-text and `literal` tokenized text fields are available to use in faceting. Full documentation on index creation can be found under our [CREATE INDEX documentation](https://www.paradedb.com/docs/documentation/indexing/create-index).
+[^1]: To create a ParadeDB search index, you would run: `CREATE INDEX ON hn_items USING paradedb (id, by, text, title, (url::pdb.literal), (type::pdb.literal), time, score) WITH (key_field=id);`. All non-text and `literal` tokenized text fields are available to use in faceting. Full documentation on index creation can be found under our [CREATE INDEX documentation](https://www.paradedb.com/docs/documentation/indexing/create-index).
 
 [^2]: [MVCC (Multi-Version Concurrency Control)](https://www.postgresql.org/docs/current/mvcc.html) is PostgreSQL's mechanism for handling concurrent transactions by maintaining multiple versions of data when rows are modified. The built in [VACUUM](https://www.postgresql.org/docs/current/routine-vacuuming.html) asynchronously cleans up these old versions. Accessing rows includes visibility checks in both tables and indexes to ensure each transaction sees the correct version of data.

--- a/src/app/blog/hybrid-search-in-postgresql-the-missing-manual/index.mdx
+++ b/src/app/blog/hybrid-search-in-postgresql-the-missing-manual/index.mdx
@@ -47,7 +47,7 @@ ParadeDB brings production-ready BM25 directly into PostgreSQL as a native index
 
 ### BM25 With ParadeDB
 
-Getting started with ParadeDB is straightforward. Once you have the extension installed, you can create BM25 indexes just like any other PostgreSQL index type, then query them with a simple operator syntax.
+Getting started with ParadeDB is straightforward. Once you have the extension installed, you can create ParadeDB indexes just like any other PostgreSQL index type, then query them with a simple operator syntax.
 
 <Note>
   To add `pg_search` to your PostgreSQL instance (or to spin up a new instance
@@ -64,9 +64,9 @@ CREATE TABLE documents (
     content TEXT
 );
 
--- Create BM25 index using the english tokenizer with stemming enabled
+-- Create ParadeDB index using the english tokenizer with stemming enabled
 CREATE INDEX idx_documents_bm25 ON documents
-USING bm25 (
+USING paradedb (
   id,
   title::pdb.simple('stemmer=english'),
   content::pdb.simple('stemmer=english')
@@ -84,7 +84,7 @@ WHERE
 ORDER BY bm25_score DESC;
 ```
 
-The `|||` operator above is for match disjunction, but many other options are available. Conjunction, phrase matching, highlighting, more like this, regex queries and word proximity are all supported. ParadeDB is also smart about query optimization. It can push down `WHERE` clauses and faceting aggregations into the BM25 index where possible, making complex filtered searches much faster than traditional approaches.
+The `|||` operator above is for match disjunction, but many other options are available. Conjunction, phrase matching, highlighting, more like this, regex queries and word proximity are all supported. ParadeDB is also smart about query optimization. It can push down `WHERE` clauses and faceting aggregations into the ParadeDB index where possible, making complex filtered searches much faster than traditional approaches.
 
 This kind of lexical search excels at exact or similar matches: it's perfect when users search for specific terms, product codes, or technical concepts they know by name (or at close, see our blog on [tokenization and stemming](/blog/when-tokenization-becomes-token) for a deep dive on how this works).
 

--- a/src/app/blog/increased-write-performance/index.mdx
+++ b/src/app/blog/increased-write-performance/index.mdx
@@ -117,7 +117,7 @@ Our write optimizations delivered significant improvements across multiple bench
 As we've mentioned in previous blog posts the difference between v0.18.0 (no mutable segments, primarily foreground merging), v0.19.0 (mutable segments and background merging), and v0.20.0 (small improvements, and both features on by default) is large. The following test runs batched updates in a single thread at the same time as inserts and Top K queries to simulate a realistic workload (see [Stressgres, our load testing tool](https://github.com/paradedb/paradedb/tree/main/stressgres)).
 
 <BarChartCard
-title="Updates Per Second on a Wide Table with a BM25 index"
+title="Updates Per Second on a Wide Table with a ParadeDB index"
 data={[
     {
       name: "v0.20.0",

--- a/src/app/blog/introducing-search/index.mdx
+++ b/src/app/blog/introducing-search/index.mdx
@@ -61,10 +61,10 @@ is like the table of contents of a book — without it, you might have to examin
 a specific chapter.
 
 Rather than creating this inverted index externally, `pg_search` stores the
-index inside Postgres as a new, Postgres-native index type, which we call the BM25 index. This is made possible
+index inside Postgres as a new, Postgres-native index type, which we now call the ParadeDB index. This is made possible
 through Postgres' [index access method](https://www.postgresql.org/docs/current/indexam.html) API.
 
-When a BM25 index is created, Postgres automatically updates it as new data arrives
+When a ParadeDB index is created, Postgres automatically updates it as new data arrives
 or is deleted in the underlying SQL table. In this way, `pg_search` enables real-time search without any
 additional reindexing logic.
 
@@ -73,7 +73,7 @@ additional reindexing logic.
 Following index creation, the next step was to expose an intuitive SQL interface for users to write search queries.
 This was accomplished through the Postgres [operator API](https://www.postgresql.org/docs/current/sql-createoperator.html),
 which enables the creation of custom Postgres operators. We chose the `@@@` operator to signify the beginning
-of a query to the BM25 index in homage to the `@@` operator used by Postgres' native full text search.
+of a query to the ParadeDB index in homage to the `@@` operator used by Postgres' native full text search.
 
 The end result is the ability to search any table with a single SQL query.
 

--- a/src/app/blog/paradedb-0-20-0/index.mdx
+++ b/src/app/blog/paradedb-0-20-0/index.mdx
@@ -109,7 +109,7 @@ LIMIT 2;
 (2 rows)
 ```
 
-Behind the scenes, these queries use our [BM25 indexes](/learn/search-concepts/bm25) for both [full-text search](/learn/search-concepts/full-text-search) and columnar analytics. You get sub-second facet calculations across millions of documents, all while maintaining perfect consistency with your transactional data.
+Behind the scenes, these queries use ParadeDB indexes with [BM25 ranking](/learn/search-concepts/bm25) for both [full-text search](/learn/search-concepts/full-text-search) and columnar analytics. You get sub-second facet calculations across millions of documents, all while maintaining perfect consistency with your transactional data.
 
 ## v2 API: Less Magic, More Clarity
 
@@ -136,7 +136,7 @@ We've had many users see unexpected behaviors in their first few queries due to 
 
 ```sql
 CREATE INDEX search_idx ON mock_items
-USING bm25 (id,
+USING paradedb (id,
            title,
            (description::pdb.simple('stemmer=english',
                                     'stopwords_language=english')),
@@ -181,7 +181,7 @@ Our solution is based on two key optimizations from `0.19.0`, now enabled by def
 Since we first introduced these features in `0.19.0` we've increased single row update performance by more than **two orders of magnitude**; the kind of improvement that can change how you think about transactional search.
 
 <BarChartCard
-  title="Updates Per Second on a Wide Table with a BM25 index"
+  title="Updates Per Second on a Wide Table with a ParadeDB index"
   data={[
     {
       name: "v0.20.0",

--- a/src/app/blog/personalized-search-in-postgresql/index.mdx
+++ b/src/app/blog/personalized-search-in-postgresql/index.mdx
@@ -93,11 +93,11 @@ CREATE TABLE users (
 );
 ```
 
-Movies get a ParadeDB BM25 index.
+Movies get a ParadeDB index.
 
 ```sql
 CREATE INDEX movies_search_idx ON movies
-  USING bm25 (movie_id, title, year, imdb_id, tmdb_id, genres)
+  USING paradedb (movie_id, title, year, imdb_id, tmdb_id, genres)
   WITH (key_field='movie_id');
 ```
 
@@ -238,8 +238,8 @@ The in-database approach hits a sweet spot for 95% of use cases. You get hybrid 
 
 The main consideration? **Resource Management**. Because search runs on your database, it shares CPU and RAM with your transactional workload. For most applications, this is a non-issue given Postgres's efficiency. For high-scale deployments, you can run search on a **dedicated read replica** to isolate inference load from your primary writes. ParadeDB supports two approaches:
 
-- **Physical replication**: The BM25 index exists on the primary. Small write cost, but read queries can be routed to specific full replicas.
-- **Logical replication**: The BM25 index is isolated to a replica subset only. No transactionality guarantees, but proper workload isolation.
+- **Physical replication**: The ParadeDB index exists on the primary. Small write cost, but read queries can be routed to specific full replicas.
+- **Logical replication**: The ParadeDB index is isolated to a replica subset only. No transactionality guarantees, but proper workload isolation.
 
 The best approach depends on your infrastructure and requirements.
 

--- a/src/app/blog/railway/index.mdx
+++ b/src/app/blog/railway/index.mdx
@@ -50,7 +50,7 @@ psql $DATABASE_PUBLIC_URL
 
 ## Try a Quick Search Query
 
-Once connected, you can immediately start using ParadeDB's search features. Load the sample table, create a BM25 index, and run a full-text search:
+Once connected, you can immediately start using ParadeDB's search features. Load the sample table, create a ParadeDB index, and run a full-text search:
 
 ```sql
 CALL paradedb.create_bm25_test_table(
@@ -59,7 +59,7 @@ CALL paradedb.create_bm25_test_table(
 );
 
 CREATE INDEX search_idx ON mock_items
-USING bm25 (id, description, category, rating, in_stock, created_at, metadata, weight_range)
+USING paradedb (id, description, category, rating, in_stock, created_at, metadata, weight_range)
 WITH (key_field='id');
 
 SELECT description, pdb.score(id)

--- a/src/app/blog/render/index.mdx
+++ b/src/app/blog/render/index.mdx
@@ -54,7 +54,7 @@ Replace `srv-XXXXXXXXXXXXX` with your service ID from the Render dashboard, and 
 
 ## Try a Quick Search Query
 
-Once connected, you can immediately start using ParadeDB's search features. Load the sample table, create a BM25 index, and run a full-text search:
+Once connected, you can immediately start using ParadeDB's search features. Load the sample table, create a ParadeDB index, and run a full-text search:
 
 ```sql
 CALL paradedb.create_bm25_test_table(
@@ -63,7 +63,7 @@ CALL paradedb.create_bm25_test_table(
 );
 
 CREATE INDEX search_idx ON mock_items
-USING bm25 (id, description, category, rating, in_stock, created_at, metadata, weight_range)
+USING paradedb (id, description, category, rating, in_stock, created_at, metadata, weight_range)
 WITH (key_field='id');
 
 SELECT description, pdb.score(id)

--- a/src/app/blog/v2api/index.mdx
+++ b/src/app/blog/v2api/index.mdx
@@ -48,11 +48,11 @@ Table "public.mock_items"
  weight_range          | int4range
 ```
 
-With the v2 API, creating a [BM25 search index](https://www.paradedb.com/docs/documentation/indexing/create-index) is straightforward:
+With the v2 API, creating a [ParadeDB index](https://www.paradedb.com/docs/documentation/indexing/create-index) is straightforward:
 
 ```sql
 CREATE INDEX search_idx ON mock_items
-USING bm25 (id, description, category, rating, in_stock,
+USING paradedb (id, description, category, rating, in_stock,
             created_at, metadata, weight_range)
 WITH (key_field='id');
 ```
@@ -133,7 +133,7 @@ One feature we really like is the ability to tokenize the same column multiple w
 
 ```sql
 CREATE INDEX search_idx ON mock_items
-USING bm25 (
+USING paradedb (
     id,
     description,                                        -- Standard word tokenization
     (description::pdb.ngram(3,3, 'alias=desc_ngram'))   -- Partial matching
@@ -146,7 +146,7 @@ This example shows how you can apply different tokenization strategies to the sa
 
 ```sql
 CREATE INDEX search_idx ON mock_items
-USING bm25 (
+USING paradedb (
     id,
     (description::pdb.simple(
         'stemmer=english',              -- "running" matches "runs"
@@ -166,7 +166,7 @@ Modern applications increasingly rely on semi-structured data stored in JSON (or
 ```sql
 -- All JSON fields are automatically indexed
 CREATE INDEX search_idx ON mock_items
-USING bm25 (id, metadata) WITH (key_field='id');
+USING paradedb (id, metadata) WITH (key_field='id');
 
 -- Query nested properties directly
 SELECT description FROM mock_items
@@ -179,7 +179,7 @@ You can also index only specific parts of a JSON schema:
 
 ```sql
 CREATE INDEX search_idx ON mock_items
-USING bm25 (
+USING paradedb (
     id,
     description,
     ((metadata->'color')::pdb.literal('alias=json_color'))
@@ -391,7 +391,7 @@ LIMIT 2;
 (2 rows)
 ```
 
-Both queries use window functions (`OVER` clauses) to return only the top 2 results while computing analytics over all matching documents. This eliminates the need for separate queries and makes it possible to build rich search interfaces with a single efficient operation using ParadeDB's BM25 indexes.
+Both queries use window functions (`OVER` clauses) to return only the top 2 results while computing analytics over all matching documents. This eliminates the need for separate queries and makes it possible to build rich search interfaces with a single efficient operation using ParadeDB indexes.
 
 We'll have a full post coming up on how we built this search aggregations system and its performance characteristics.
 

--- a/src/app/learn/search-in-postgresql/bm25/index.mdx
+++ b/src/app/learn/search-in-postgresql/bm25/index.mdx
@@ -65,21 +65,21 @@ RETURNS VOID
 
 Unfortunately this approach is still very slow, and the tables (and their indexes) need to be updated after every source data change which leads to write amplification.
 
-### Extending Postgres to Support BM25 Indexes
+### Extending Postgres with ParadeDB Indexes
 
-A more scalable approach is using Postgres's index access method (IAM) to create a native BM25 index that is created on the source table.
+A more scalable approach is using Postgres's index access method (IAM) to create a native ParadeDB index on the source table.
 
-[ParadeDB](https://www.paradedb.com) uses this method to implement BM25 indexes in Rust, adding them to PostgreSQL though the open-source `pg_search` extension.
+[ParadeDB](https://www.paradedb.com) implements ParadeDB indexes in Rust, adding BM25 ranking and search capabilities to PostgreSQL through the open-source `pg_search` extension.
 
 When an index is added to a table it can cover multiple columns, providing advanced full-text search DX, as well as fast columnar lookups and aggregations for non-text fields.
 
 ```sql
 CREATE INDEX search_idx ON mock_items
-USING bm25 (id, description, category, rating)
+USING paradedb (id, description, category, rating)
 WITH (key_field='id');
 ```
 
-The BM25 index is laid out on disk as an [**LSM tree**](https://www.paradedb.com/docs/welcome/architecture#lsm-tree), where each segment in the tree consists of both an inverted index and columnar index. The inverted and columnar indexes optimize for fast reads, while the LSM tree optimizes for high-frequency writes.
+The ParadeDB index is laid out on disk as an [**LSM tree**](https://www.paradedb.com/docs/welcome/architecture#lsm-tree), where each segment in the tree consists of both an inverted index and columnar index. The inverted and columnar indexes optimize for fast reads, while the LSM tree optimizes for high-frequency writes.
 
 ParadeDB users can access full-text search and BM25 relevancy ranking by using custom operators and functions. For example, a search using match disjunction (find all documents which match one or more terms), ordering by BM25 scores, and then returning the top 5 would look like this:
 
@@ -99,7 +99,7 @@ Bringing BM25 directly into Postgres has two major effects: it improves ranking 
 
 Postgres’s built-in full-text search—based on tsvector, tsquery, and ts_rank is capable but rudimentary. Its scoring function uses a linear weighting of term frequency and field importance, but it ignores inverse document frequency (IDF) and applies no document-length normalization.
 
-Running BM25 inside Postgres also eliminates the need for a separate search engine and the ETL processes that keep it synchronized. There’s no risk of stale indexes, no duplicate infrastructure, and no latency gap between writes and searchable data. Each change to a table immediately updates the BM25 index, keeping search results transactionally consistent with the source of truth.
+Running BM25 inside Postgres also eliminates the need for a separate search engine and the ETL processes that keep it synchronized. There’s no risk of stale indexes, no duplicate infrastructure, and no latency gap between writes and searchable data. Each change to a table immediately updates the ParadeDB index, keeping search results transactionally consistent with the source of truth.
 
 Finally, because BM25 operates as a native index access method, it participates in Postgres’s planner and transaction model. Queries benefit from caching, parallelism, and predictable performance characteristics: something external search engines can’t easily guarantee.
 

--- a/src/components/ui/SearchFeatures.tsx
+++ b/src/components/ui/SearchFeatures.tsx
@@ -15,7 +15,7 @@ import {
 } from "@remixicon/react";
 
 const indexingCode = `CREATE INDEX ON posts
-USING bm25 (
+USING paradedb (
     id,
     title,
     (body::pdb.unicode_words('stemmer=english')),

--- a/src/components/vs/VsBenchmarkPanel.tsx
+++ b/src/components/vs/VsBenchmarkPanel.tsx
@@ -863,7 +863,7 @@ const PDB_SCHEMA = [
   ");",
   "",
   "CREATE INDEX hn_items_idx ON hn_items",
-  "USING bm25 (",
+  "USING paradedb (",
   "  id, title, text, score, time,",
   "  (by::pdb.literal),",
   "  (type::pdb.literal),",


### PR DESCRIPTION
Updates user-facing references from “BM25 index” to “ParadeDB index” and migrates current index creation examples from `USING bm25` to `USING paradedb`. BM25 references that describe the ranking or retrieval algorithm remain unchanged.

The pass covers `/learn`, reusable website examples, the benchmark fixture, and tutorials/blog posts that readers can still copy SQL from.

Validation:
- Production build passes (`pnpm build`)
- Changed TSX components pass ESLint
- Changed prose/code files pass codespell and Prettier (the benchmark JSON retains its existing non-Prettier formatting)

Repository-wide ESLint remains blocked by the existing `react/no-unescaped-entities` error in `src/components/ui/PostgresNative.tsx:161`, unrelated to this change.