### PR TITLE
feat: new messaging (RFC)

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,3 @@
+allowBuilds:
+  sharp: true
+  unrs-resolver: true

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,3 +1,6 @@
+packages:
+  - "."
+
 allowBuilds:
   sharp: true
   unrs-resolver: true

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -732,6 +732,15 @@ a {
   );
 }
 
+.no-scrollbar {
+  scrollbar-width: none;
+  -ms-overflow-style: none;
+}
+
+.no-scrollbar::-webkit-scrollbar {
+  display: none;
+}
+
 .bg-diagonal-hatch-white {
   background-image: repeating-linear-gradient(
     -45deg,

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,6 +1,5 @@
 import Footer from "@/components/ui/Footer";
 import { Navigation } from "@/components/ui/Navbar";
-import { SiteBanner } from "@/components/ui/SiteBanner";
 import type { Metadata } from "next";
 import { ThemeProvider } from "next-themes";
 import { Inter } from "next/font/google";
@@ -119,7 +118,6 @@ export default function RootLayout({
           enableSystem={true}
           disableTransitionOnChange
         >
-          <SiteBanner />
           <div className="relative mx-auto w-full max-w-[1440px]">
             <Navigation />
           </div>

--- a/src/components/CopyToClipboard.tsx
+++ b/src/components/CopyToClipboard.tsx
@@ -3,8 +3,15 @@
 import { RiCheckLine, RiFileCopyLine } from "@remixicon/react";
 import copy from "copy-to-clipboard";
 import { useState } from "react";
+import { cx } from "@/lib/utils";
 
-export default function CopyToClipboard({ code }: { code: string }) {
+export default function CopyToClipboard({
+  code,
+  className,
+}: {
+  code: string;
+  className?: string;
+}) {
   const [copied, setCopied] = useState(false);
   const copyToClipboard = () => {
     copy(code);
@@ -16,7 +23,10 @@ export default function CopyToClipboard({ code }: { code: string }) {
     <button
       onClick={copyToClipboard}
       aria-label={copied ? "Copied" : "Copy code"}
-      className="select-none cursor-pointer rounded-md border border-white/20 bg-transparent p-1.5 transition-colors hover:text-white/90 shadow-sm"
+      className={cx(
+        "select-none cursor-pointer rounded-md border border-white/20 bg-transparent p-1.5 transition-colors hover:text-white/90 shadow-sm",
+        className,
+      )}
     >
       {!copied ? (
         <RiFileCopyLine aria-hidden="true" className="size-4 text-white" />

--- a/src/components/CopyableCommand.tsx
+++ b/src/components/CopyableCommand.tsx
@@ -1,0 +1,52 @@
+"use client";
+
+import { RiCheckLine } from "@remixicon/react";
+import copy from "copy-to-clipboard";
+import { useState } from "react";
+import { cx } from "@/lib/utils";
+
+export default function CopyableCommand({
+  code,
+  className,
+}: {
+  code: string;
+  className?: string;
+}) {
+  const [copied, setCopied] = useState(false);
+  const copyToClipboard = () => {
+    copy(code);
+    setCopied(true);
+    setTimeout(() => setCopied(false), 1500);
+  };
+
+  return (
+    <button
+      onClick={copyToClipboard}
+      aria-label="Copy command to clipboard"
+      className={cx(
+        "group relative inline-flex items-center cursor-pointer select-none font-mono",
+        className,
+      )}
+    >
+      <span className="underline underline-offset-4 decoration-white/40">
+        {code}
+      </span>
+      <span
+        role="status"
+        className={cx(
+          "pointer-events-none absolute -top-9 left-1/2 -translate-x-1/2 whitespace-nowrap rounded-md bg-slate-900 px-2.5 py-1 font-sans text-xs text-white dark:bg-white dark:text-slate-900 transition-opacity",
+          copied ? "opacity-100" : "opacity-0 group-hover:opacity-100",
+        )}
+      >
+        {copied ? (
+          <span className="inline-flex items-center gap-1">
+            <RiCheckLine className="size-3.5 text-emerald-400 dark:text-emerald-600" />
+            Copied
+          </span>
+        ) : (
+          "Click to copy"
+        )}
+      </span>
+    </button>
+  );
+}

--- a/src/components/ui/AgentReady.tsx
+++ b/src/components/ui/AgentReady.tsx
@@ -10,7 +10,7 @@ import {
   RiFileCopyLine,
   RiOpenaiFill,
 } from "@remixicon/react";
-import { Badge } from "./Badge";
+import { SectionHeader } from "./SectionHeader";
 import { JavaScriptIcon } from "./icons/JavaScriptIcon";
 import { PythonIcon } from "./icons/PythonIcon";
 import { RubyIcon } from "./icons/RubyIcon";
@@ -388,29 +388,21 @@ export default function AgentReady() {
           <div className="absolute inset-y-0 left-4 md:left-12 w-px bg-slate-200 dark:bg-slate-900 z-30 pointer-events-none" />
           <div className="absolute inset-y-0 right-4 md:right-12 w-px bg-slate-200 dark:bg-slate-900 z-30 pointer-events-none" />
 
-          <div className="px-4 md:px-12 w-full flex flex-col relative isolate">
-            <div className="absolute inset-y-0 left-4 md:left-12 right-4 md:right-12 bg-slate-100/60 dark:bg-slate-900/40 -z-10" />
-            <div className="absolute inset-y-0 left-1/2 -ml-[564px] w-px bg-slate-200 dark:bg-slate-900 z-30 pointer-events-none hidden xl:block" />
-            <div className="absolute inset-y-0 left-1/2 ml-[564px] w-px bg-slate-200 dark:bg-slate-900 z-30 pointer-events-none hidden xl:block" />
-
-            <div className="relative flex flex-col items-center justify-center py-10 sm:py-16 bg-transparent z-20">
+          <div className="px-4 md:px-12 w-full flex flex-col relative">
+            <div className="relative flex flex-col items-center justify-center py-10 sm:py-16 bg-transparent">
               {/* Header section */}
-              <div className="flex flex-col items-center w-full relative z-20 px-6 sm:px-0 text-center mb-12">
-                <Badge className="mb-6">Integrations</Badge>
-                <h2 className="text-3xl sm:text-4xl font-bold tracking-tighter text-indigo-950 dark:text-white sm:text-6xl mb-4">
-                  Use with your{" "}
-                  <span className="text-indigo-600 dark:text-indigo-400">
-                    favorite
-                  </span>{" "}
-                  tools.
-                </h2>
-                <p className="text-base sm:text-lg text-gray-800 dark:text-slate-300 max-w-2xl mx-auto leading-relaxed">
-                  ParadeDB works seamlessly with your existing stack.
-                </p>
+              <div className="mx-auto w-full max-w-[1128px] px-4 sm:px-12 xl:px-0 relative mb-12">
+                <SectionHeader
+                  eyebrow="Integrations"
+                  title="Use with your favorite tools."
+                  description="ParadeDB works seamlessly with your existing stack."
+                />
               </div>
 
               {/* Nested Cards Container */}
               <div className="relative w-full z-20">
+                <div className="absolute inset-y-0 left-1/2 -ml-[564px] w-px bg-slate-200 dark:bg-slate-900 z-30 pointer-events-none hidden xl:block" />
+                <div className="absolute inset-y-0 left-1/2 ml-[564px] w-px bg-slate-200 dark:bg-slate-900 z-30 pointer-events-none hidden xl:block" />
                 <div className="max-w-[1128px] mx-auto grid grid-cols-1 lg:grid-cols-3 divide-y lg:divide-y-0 lg:divide-x divide-slate-200 dark:divide-slate-800 border-y border-slate-200 dark:border-slate-800 bg-white dark:bg-slate-900/50">
                   {/* Card 2: Cloud Platforms */}
                   <div className="flex flex-col h-full relative overflow-hidden bg-white dark:bg-slate-900/40">

--- a/src/components/ui/Architecture.tsx
+++ b/src/components/ui/Architecture.tsx
@@ -1,39 +1,34 @@
 "use client";
 
-import { useState, type ReactNode } from "react";
+import { type ReactNode } from "react";
 import {
   RiBubbleChartLine,
   RiDatabase2Line,
-  RiSparklingLine,
   RiFlashlightLine,
   RiLayoutVerticalLine,
-  RiRefreshLine,
   RiSearchLine,
-  RiStackLine,
 } from "@remixicon/react";
-import { Badge } from "./Badge";
+import { SectionHeader } from "./SectionHeader";
 import PixelShadow from "./PixelShadow";
 import { cx } from "@/lib/utils";
 
 const SHADOW_INDIGO = "#4f46e5";
 const SHADOW_SLATE = "#64748b";
 
-type Tab = "search" | "oltp";
-
-const TABS: { id: Tab; number: string; label: string }[] = [
-  { id: "oltp", number: "01", label: "More than an OLTP database" },
-  { id: "search", number: "02", label: "More than a search engine" },
+const CARDS: { number: string; title: string; body: ReactNode }[] = [
+  {
+    number: "01",
+    title: "More than OLTP",
+    body: "OLTP databases are built for reliable transactions, but not for search. The ParadeDB index brings search-optimized data structures and query execution paths to Postgres.",
+  },
+  {
+    number: "02",
+    title: "More than search",
+    body: "Search engines operate on a denormalized copy of your data. ParadeDB keeps your application data in one place without any schema changes.",
+  },
 ];
 
-const SUBHEAD: Record<Tab, ReactNode> = {
-  search:
-    "Search engines are built for relevant search, but they operate on a denormalized copy of your data. ParadeDB is both a search index and a Postgres database, keeping the data your application needs in one place.",
-  oltp: "OLTP databases are built for reliable transactions, but not for search or analytics. ParadeDB adds full-text, vector, and aggregates, all in one custom Postgres index.",
-};
-
 export default function Architecture() {
-  const [activeTab, setActiveTab] = useState<Tab>("oltp");
-
   const tableBox = (
     <Box emphasis="slate">
       <div className="flex flex-col items-center gap-2.5">
@@ -97,33 +92,6 @@ export default function Architecture() {
     </Box>
   );
 
-  const benefits: { icon: ReactNode; title: string; body: string }[] =
-    activeTab === "search"
-      ? [
-          {
-            icon: <RiStackLine className="size-5 shrink-0" />,
-            title: "One database to run",
-            body: "No separate search system to deploy or keep in sync.",
-          },
-          {
-            icon: <RiRefreshLine className="size-5 shrink-0" />,
-            title: "Always in sync",
-            body: "Search results reflect every write the moment it lands.",
-          },
-        ]
-      : [
-          {
-            icon: <RiStackLine className="size-5 shrink-0" />,
-            title: "One search index",
-            body: "A single index covering all parts of search unlocks pre-filtering and query optimization.",
-          },
-          {
-            icon: <RiSparklingLine className="size-5 shrink-0" />,
-            title: "A full search engine in your database",
-            body: "BM25 relevance, vector search, faceting, and hybrid ranking, all in standard SQL.",
-          },
-        ];
-
   const arrowColor = "text-slate-400 dark:text-slate-600";
 
   const syncArrowHorizontal = (
@@ -180,148 +148,84 @@ export default function Architecture() {
         {/* Top hatched border */}
         <div className="h-8 md:h-12 w-full bg-diagonal-hatch border-y border-slate-200 dark:border-slate-900 relative z-20 bg-slate-50/50 dark:bg-slate-900/50 opacity-60" />
 
-        <section className="relative py-10 md:py-14 border-r border-l border-slate-200 dark:border-slate-900 bg-slate-100/60 dark:bg-slate-900/40">
-          {/* Inner grid lines */}
-          <div className="absolute inset-y-0 left-1/2 -ml-[564px] w-px bg-slate-200 dark:bg-slate-900 z-30 pointer-events-none hidden xl:block" />
-          <div className="absolute inset-y-0 left-1/2 ml-[564px] w-px bg-slate-200 dark:bg-slate-900 z-30 pointer-events-none hidden xl:block" />
-
+        <section className="relative z-40 py-10 md:py-14 border-r border-l border-slate-200 dark:border-slate-900">
           {/* Header */}
-          <div className="flex flex-col items-center text-center px-6 sm:px-12 mb-10 md:mb-12">
-            <Badge className="mb-6">Architecture</Badge>
-            <h2 className="text-3xl sm:text-4xl font-bold tracking-tighter text-indigo-950 dark:text-white sm:text-6xl max-w-4xl">
-              <span className="text-highlight-blink">One database</span>, two
-              workloads.
-            </h2>
+          <div className="mx-auto w-full max-w-[1128px] px-4 sm:px-12 xl:px-0 mb-10 md:mb-12">
+            <SectionHeader
+              eyebrow="Benefits"
+              title="Zero ETL means zero headache."
+              description="The ParadeDB index always stays in sync with your application data."
+            />
           </div>
 
-          {/* Tab control: aligned to the diagram width, styled like the Workloads tabs */}
-          <div className="px-4 mb-10 md:mb-12">
-            <div className="mx-auto w-full max-w-[1128px] overflow-x-auto pb-px no-scrollbar border-t-1 border-b-1 border-slate-200 dark:border-slate-900">
-              <div
-                role="tablist"
-                aria-label="Architecture comparison"
-                className="flex w-full min-w-max items-end"
-              >
-                {TABS.map((tab) => {
-                  const isActive = activeTab === tab.id;
-                  return (
-                    <button
-                      key={tab.id}
-                      role="tab"
-                      aria-selected={isActive}
-                      onClick={() => setActiveTab(tab.id)}
-                      className={cx(
-                        "group relative flex-shrink-0 sm:flex-1 flex items-center justify-center gap-3 px-6 py-3 text-sm font-medium transition-all outline-none border-b-2 whitespace-nowrap",
-                        isActive
-                          ? "border-indigo-600 text-indigo-900 dark:text-white"
-                          : "border-transparent text-slate-500 hover:text-slate-700 dark:hover:text-slate-300",
-                      )}
-                    >
-                      <span
-                        className={cx(
-                          "text-xs font-mono font-semibold",
-                          isActive
-                            ? "text-indigo-600 dark:text-indigo-400 opacity-100"
-                            : "opacity-50",
-                        )}
-                      >
-                        {tab.number}
-                      </span>
-                      <span className="text-sm sm:text-base font-semibold tracking-tight">
-                        {tab.label}
-                      </span>
-                    </button>
-                  );
-                })}
-              </div>
-            </div>
-          </div>
+          <div className="relative">
+            {/* Inner grid lines, below the header */}
+            <div className="absolute inset-y-0 left-1/2 -ml-[564px] w-px bg-slate-200 dark:bg-slate-900 z-30 pointer-events-none hidden xl:block" />
+            <div className="absolute inset-y-0 left-1/2 ml-[564px] w-px bg-slate-200 dark:bg-slate-900 z-30 pointer-events-none hidden xl:block" />
 
-          {/* Subhead */}
-          <div className="flex flex-col items-center text-center px-6 sm:px-12 mb-10 md:mb-12">
-            <div className="relative grid w-full max-w-4xl items-center">
-              {TABS.map((tab) => {
-                const isActive = activeTab === tab.id;
-                return (
-                  <p
-                    key={tab.id}
-                    aria-hidden={!isActive}
-                    className={cx(
-                      "col-start-1 row-start-1 text-base sm:text-lg text-gray-800 dark:text-slate-300 leading-relaxed transition-opacity duration-300",
-                      isActive
-                        ? "opacity-100"
-                        : "opacity-0 pointer-events-none",
-                    )}
-                  >
-                    {SUBHEAD[tab.id]}
-                  </p>
-                );
-              })}
-            </div>
-          </div>
-
-          {/* Architecture diagram */}
-          <div className="px-4">
-            <div className="w-full max-w-[1128px] mx-auto">
-              <div
-                role="img"
-                aria-label="ParadeDB architecture: a table heap in Postgres and a ParadeDB index with full-text, vector, and aggregate workloads."
-                className="font-mono"
-              >
-                {/* PostgreSQL frame: label inside, border around the whole diagram */}
-                <div className="relative border xl:border-x-0 border-slate-200 dark:border-slate-900 p-4 sm:p-5 md:p-6">
-                  {/* Inner frame: PostgreSQL label straddling its top border */}
-                  <div className="relative border border-t-0 border-slate-200 dark:border-slate-900 bg-white dark:bg-slate-950 px-5 pt-12 pb-10 sm:px-8 sm:pt-14 sm:pb-12 md:px-10 md:pt-[4.5rem] md:pb-16">
-                    <div className="absolute inset-x-0 top-0 -translate-y-1/2 flex items-center gap-3 font-mono text-sm font-bold text-slate-900 dark:text-white">
-                      <span
-                        aria-hidden
-                        className="h-px flex-1 bg-slate-200 dark:bg-slate-900"
-                      />
-                      PostgreSQL
-                      <span
-                        aria-hidden
-                        className="h-px flex-1 bg-slate-200 dark:bg-slate-900"
-                      />
-                    </div>
-                    <div className="max-w-[900px] mx-auto">
-                      {/* Mobile/tablet layout (< xl): vertical stack */}
-                      <div className="xl:hidden flex flex-col items-stretch gap-3">
-                        {tableBox}
-                        <div className="flex justify-center mt-3">
-                          {syncArrowVertical}
+            {/* Architecture diagram */}
+            <div className="px-4">
+              <div className="w-full max-w-[1128px] mx-auto">
+                <div
+                  role="img"
+                  aria-label="ParadeDB architecture: a table heap in Postgres and a ParadeDB index with full-text, vector, and aggregate workloads."
+                  className="font-mono"
+                >
+                  {/* PostgreSQL frame: label inside, border around the whole diagram */}
+                  <div className="relative border xl:border-x-0 border-slate-200 dark:border-slate-900 p-4 sm:p-5 md:p-6">
+                    {/* Inner frame: PostgreSQL label straddling its top border */}
+                    <div className="relative border border-t-0 border-slate-200 dark:border-slate-900 bg-white dark:bg-slate-950 px-5 pt-12 pb-10 sm:px-8 sm:pt-14 sm:pb-12 md:px-10 md:pt-[4.5rem] md:pb-16">
+                      <div className="absolute inset-x-0 top-0 -translate-y-1/2 flex items-center gap-3 font-mono text-sm font-bold text-slate-900 dark:text-white">
+                        <span
+                          aria-hidden
+                          className="h-px flex-1 bg-slate-200 dark:bg-slate-900"
+                        />
+                        PostgreSQL
+                        <span
+                          aria-hidden
+                          className="h-px flex-1 bg-slate-200 dark:bg-slate-900"
+                        />
+                      </div>
+                      <div className="max-w-[900px] mx-auto">
+                        {/* Mobile/tablet layout (< xl): vertical stack */}
+                        <div className="xl:hidden flex flex-col items-stretch gap-3">
+                          {tableBox}
+                          <div className="flex justify-center mt-3">
+                            {syncArrowVertical}
+                          </div>
+                          {indexBox}
                         </div>
-                        {indexBox}
-                      </div>
 
-                      {/* Desktop layout (xl+): horizontal grid */}
-                      <div className="hidden xl:grid gap-x-6 items-center grid-cols-[1fr_auto_1fr]">
-                        {tableBox}
-                        {syncArrowHorizontal}
-                        {indexBox}
-                      </div>
-                    </div>
-                  </div>
-
-                  {/* Benefits band: attached to the white diagram box, sharing its border */}
-                  <div className="border border-t-0 border-slate-200 dark:border-slate-900 bg-white dark:bg-slate-950 grid grid-cols-1 divide-y divide-slate-200 dark:divide-slate-900 sm:grid-cols-2 sm:divide-y-0 sm:divide-x">
-                    {benefits.map((benefit) => (
-                      <div
-                        key={benefit.title}
-                        className="flex items-start gap-3 px-5 py-4 sm:px-6 sm:py-5"
-                      >
-                        <span className="mt-0.5 text-indigo-600 dark:text-indigo-400">
-                          {benefit.icon}
-                        </span>
-                        <div>
-                          <div className="font-sans text-base font-semibold text-indigo-950 dark:text-white tracking-tight">
-                            {benefit.title}
-                          </div>
-                          <div className="font-sans text-sm leading-relaxed text-slate-600 dark:text-slate-400 min-h-[2lh]">
-                            {benefit.body}
-                          </div>
+                        {/* Desktop layout (xl+): horizontal grid */}
+                        <div className="hidden xl:grid gap-x-6 items-center grid-cols-[1fr_auto_1fr]">
+                          {tableBox}
+                          {syncArrowHorizontal}
+                          {indexBox}
                         </div>
                       </div>
-                    ))}
+                    </div>
+
+                    {/* Content cards: attached to the white diagram box, sharing its border */}
+                    <div className="border border-t-0 border-slate-200 dark:border-slate-900 bg-slate-200 dark:bg-slate-900 grid grid-cols-1 sm:grid-cols-2 gap-px">
+                      {CARDS.map((card) => (
+                        <div
+                          key={card.title}
+                          className="px-5 py-5 sm:px-6 sm:py-6 bg-white dark:bg-slate-950"
+                        >
+                          <div className="flex items-center gap-3 mb-3">
+                            <span className="font-mono text-xs font-semibold text-indigo-600 dark:text-indigo-400">
+                              {card.number}
+                            </span>
+                            <h3 className="font-sans font-semibold text-base tracking-tight text-indigo-950 dark:text-white">
+                              {card.title}
+                            </h3>
+                          </div>
+                          <p className="font-sans text-sm leading-relaxed text-slate-600 dark:text-slate-400">
+                            {card.body}
+                          </p>
+                        </div>
+                      ))}
+                    </div>
                   </div>
                 </div>
               </div>

--- a/src/components/ui/Architecture.tsx
+++ b/src/components/ui/Architecture.tsx
@@ -154,7 +154,7 @@ export default function Architecture() {
             <SectionHeader
               eyebrow="Benefits"
               title="Zero ETL means zero headache."
-              description="The ParadeDB index always stays in sync with your application data."
+              description="Ship features, not infra complexity. ParadeDB is a single index that always stays in sync with your application data."
             />
           </div>
 

--- a/src/components/ui/Benchmark.tsx
+++ b/src/components/ui/Benchmark.tsx
@@ -1,7 +1,7 @@
 // Link + arrow used by the commented-out "See the full comparison" CTA below.
 // import Link from "next/link";
 // import { RiArrowRightLine } from "@remixicon/react";
-import { Badge } from "./Badge";
+import { SectionHeader } from "./SectionHeader";
 import BenchmarkPanel from "./BenchmarkPanel";
 
 export default function Benchmark() {
@@ -21,18 +21,13 @@ export default function Benchmark() {
           <div className="absolute inset-y-0 left-1/2 ml-[564px] w-px bg-slate-200 dark:bg-slate-900 z-30 pointer-events-none hidden xl:block" />
 
           <div className="mx-auto w-full max-w-[1128px] px-4 sm:px-12 xl:px-0">
-            {/* Header, centered above the full-width card */}
-            <div className="flex flex-col items-center text-center mb-8 md:mb-10">
-              <Badge className="mb-5">Benchmark</Badge>
-              <h2 className="text-3xl sm:text-4xl font-bold tracking-tighter text-indigo-950 dark:text-white sm:text-6xl mb-4">
-                Elastic-quality{" "}
-                <span className="text-highlight-blink">performance</span>.
-              </h2>
-              <p className="max-w-2xl text-base sm:text-lg text-gray-800 dark:text-slate-300 leading-relaxed">
-                Built on Tantivy, the Rust port of Lucene, ParadeDB goes
-                toe-to-toe with dedicated search-engines on full text search,
-                often coming out on top.
-              </p>
+            {/* Header, aligned above the full-width card */}
+            <div className="flex flex-col items-start text-left mb-8 md:mb-10">
+              <SectionHeader
+                eyebrow="Benchmark"
+                title="Elastic-quality performance."
+                description="Built on Tantivy, the Rust port of Lucene, ParadeDB goes toe-to-toe with dedicated search-engines on full text search, often coming out on top."
+              />
               {/* Hidden until the /vs/elasticsearch page ships
               <Link
                 href="/vs/elasticsearch"

--- a/src/components/ui/CommunityProof.tsx
+++ b/src/components/ui/CommunityProof.tsx
@@ -1,6 +1,5 @@
 import Link from "next/link";
 import { RiArrowRightLine, RiGithubFill } from "@remixicon/react";
-import { Badge } from "./Badge";
 import DockerLogo from "./DockerLogo";
 import PostgresLogo from "./PostgresLogo";
 import { documentation, github } from "@/lib/links";
@@ -18,16 +17,21 @@ export default function CommunityProof() {
 
           {/* Section: Loved by Developers (White Background) */}
           <div className="relative flex flex-col items-center justify-center bg-white dark:bg-slate-950">
-            <div className="relative w-full z-20">
+            <div className="relative w-full">
               <div className="grid grid-cols-1 md:grid-cols-4 bg-white dark:bg-slate-950 divide-y md:divide-y-0 divide-slate-200 dark:divide-slate-900">
                 {/* Heading Column */}
                 <div className="p-8 md:p-12 md:py-24 text-left flex flex-col items-start md:border-r border-slate-200 dark:border-slate-900">
-                  <Badge className="mb-6">Open Source</Badge>
-                  <h2 className="text-3xl font-bold tracking-tighter text-indigo-950 dark:text-white mb-4">
-                    <span className="text-highlight-blink">Loved</span> by
-                    developers.
+                  <p className="font-mono text-xs uppercase tracking-widest text-indigo-600 dark:text-indigo-400 mb-3">
+                    Open Source
+                  </p>
+                  <h2 className="relative text-2xl sm:text-3xl font-semibold tracking-tight leading-[1.15] text-slate-900 dark:text-white mb-4">
+                    <span
+                      aria-hidden="true"
+                      className="hidden sm:block absolute -left-8 md:-left-12 translate-x-[calc(-50%+0.5px)] top-[0.15em] h-[0.9em] w-[3px] bg-indigo-600 z-40"
+                    />
+                    Loved by developers.
                   </h2>
-                  <p className="text-md text-gray-800 dark:text-slate-300 leading-relaxed">
+                  <p className="text-md text-slate-600 dark:text-slate-300 leading-relaxed">
                     We are committed to building the best open source search
                     experience for Postgres.
                   </p>

--- a/src/components/ui/DarkModeOverlay.tsx
+++ b/src/components/ui/DarkModeOverlay.tsx
@@ -1,9 +1,12 @@
 "use client";
 
 import { useTheme } from "next-themes";
+import { useEffect, useState } from "react";
 
 export function DarkModeOverlay() {
   const { resolvedTheme } = useTheme();
-  if (resolvedTheme !== "dark") return null;
+  const [mounted, setMounted] = useState(false);
+  useEffect(() => setMounted(true), []);
+  if (!mounted || resolvedTheme !== "dark") return null;
   return <div className="absolute inset-0 bg-black/5 pointer-events-none" />;
 }

--- a/src/components/ui/Hero.tsx
+++ b/src/components/ui/Hero.tsx
@@ -4,10 +4,9 @@ import { siteConfig } from "@/app/siteConfig";
 import Link from "next/link";
 import { Button } from "../Button";
 import LogoCloud from "./LogoCloud";
-import { HeroVisual } from "./HeroVisual";
 import { DarkModeOverlay } from "./DarkModeOverlay";
-import Code from "@/components/Code";
-import CopyToClipboard from "@/components/CopyToClipboard";
+import { HeroVisual } from "./HeroVisual";
+import CopyableCommand from "@/components/CopyableCommand";
 
 const installCommand = `curl -fsSL https://paradedb.com/install.sh | sh`;
 
@@ -23,31 +22,40 @@ export default async function Hero() {
       >
         {/* Top Shaded Region */}
         <div className="absolute top-[64px] md:top-[80px] left-4 md:left-12 right-4 md:right-12 z-20">
-          <div className="h-8 md:h-12 w-full bg-diagonal-hatch-white border-b border-white/20 bg-indigo-700/20 opacity-60" />
+          <div className="h-8 md:h-12 w-full bg-diagonal-hatch-white bg-indigo-700/20 opacity-60" />
         </div>
 
         {/* Horizontal line below top shaded region - constrained to vertical lines */}
         <div className="absolute top-[96px] md:top-[128px] left-4 md:left-12 right-4 md:right-12 h-px bg-white/20 z-30" />
 
         <div className="px-4 md:px-12 w-full h-full flex flex-col flex-grow relative">
-          <div className="relative flex flex-col items-center justify-center sm:pt-48 pt-36 text-center px-6 sm:px-0">
-            <div className="flex flex-col items-center w-full relative z-20">
+          <div className="relative flex flex-col items-start justify-center sm:pt-56 pt-40 text-left px-6 sm:px-16 lg:px-24">
+            <div className="flex flex-col items-start w-full max-w-4xl relative z-40">
+              <Link
+                href={siteConfig.baseLinks.cloud}
+                className="group inline-flex items-center gap-2 rounded-none border border-white/30 bg-white/10 px-3 py-1 mb-6 text-xs sm:text-sm font-medium text-indigo-100 transition-colors hover:border-white/60 hover:text-white opacity-0 animate-hero-title"
+              >
+                <span className="size-1.5 rounded-full bg-white" />
+                ParadeDB Cloud is coming
+              </Link>
               <h1
                 id="hero-title"
-                className="inline-block py-2 text-4xl font-bold tracking-tighter text-white sm:text-7xl opacity-0 animate-hero-title"
+                className="relative inline-block text-2xl sm:text-5xl font-bold tracking-tighter leading-[1.15] text-white opacity-0 animate-hero-title"
               >
-                Search without <br className="hidden sm:block" /> a{" "}
-                <span className="text-white/90">second system</span>.
+                <span
+                  aria-hidden="true"
+                  className="hidden sm:block absolute -left-16 lg:-left-24 translate-x-[calc(-50%+0.5px)] top-[0.15em] h-[0.9em] w-[3px] bg-white z-40"
+                />
+                Make slow search queries fly in Postgres.
               </h1>
             </div>
 
             {/* Bottom Content - In front of everything */}
-            <div className="relative z-20 mt-auto flex flex-col items-center opacity-0 animate-hero-content">
-              <p className="text-base sm:text-lg text-indigo-50 mb-8 mt-4 max-w-2xl">
-                One Postgres for your application data, full-text search, vector
-                retrieval, and aggregations.
+            <div className="relative z-20 mt-auto flex flex-col items-start w-full max-w-4xl opacity-0 animate-hero-content">
+              <p className="text-lg sm:text-xl font-normal leading-[1.4] text-indigo-100 mt-6 mb-8">
+              One Postgres platform for your hardest search queries. Text and vector search, filters, facets, and joins where your OLTP database falls short.
               </p>
-              <div className="flex flex-col sm:flex-row items-center gap-4 w-full max-w-sm sm:max-w-none sm:w-auto justify-center mb-6 sm:mb-8 sm:px-0">
+              <div className="flex flex-col sm:flex-row items-center gap-4 w-full max-w-sm sm:max-w-none sm:w-auto justify-start mb-6 sm:mb-8 sm:px-0">
                 <Button
                   asChild
                   className="text-md px-4 bg-white rounded-none h-10 text-indigo-600 hover:bg-indigo-50 w-full sm:w-auto border-0 shadow-none"
@@ -59,7 +67,7 @@ export default async function Hero() {
                 <Button
                   asChild
                   variant="ghost"
-                  className="text-md hover:group hover:bg-white/10 bg-transparent border-none h-10 px-4 hover:bg-transparent dark:hover:bg-transparent w-full sm:w-auto"
+                  className="text-md hover:group bg-transparent border-none h-10 px-4 hover:bg-transparent dark:hover:bg-transparent w-full sm:w-auto"
                 >
                   <Link
                     href={siteConfig.baseLinks.cloud}
@@ -73,33 +81,28 @@ export default async function Hero() {
                   </Link>
                 </Button>
               </div>
-              <div className="hidden sm:block w-full max-w-lg mt-3 sm:mt-4 mb-2 sm:mb-4">
-                <div className="relative bg-white/10 backdrop-blur-md border border-white/20 overflow-hidden">
-                  <div className="absolute right-3 top-3 z-10">
-                    <CopyToClipboard code={installCommand} />
-                  </div>
-                  <Code
-                    code={installCommand}
-                    lang="bash"
-                    copy={false}
-                    className="text-left [&_pre]:!bg-transparent [&_.shiki]:!bg-transparent [&>div>div]:!bg-transparent dark:[&_pre]:!bg-transparent dark:[&_.shiki]:!bg-transparent dark:[&>div>div]:!bg-transparent [&_code]:text-white [&_.line]:text-white [&_span]:!text-white [&_.line::before]:!hidden [&_pre]:!py-5 [&_pre]:!pl-5 [&_pre]:!pr-12"
-                  />
-                </div>
+              <div className="hidden sm:flex items-center gap-2 mt-3 mb-2 sm:mb-4 font-mono text-sm text-white">
+                <span>Or run locally with</span>
+                <CopyableCommand code={installCommand} />
               </div>
             </div>
+
           </div>
         </div>
 
-        {/* New Colorful Visual Section */}
-        <div className="relative z-20">
+        {/* Dithered wave */}
+        <div className="relative z-10 -mt-2 md:-mt-3">
           <HeroVisual />
         </div>
 
         <div className="mt-0 relative z-20 w-full">
           <div className="px-4 md:px-12 w-full mx-auto relative">
             <div className="absolute top-0 left-4 md:left-12 right-4 md:right-12 h-px bg-white/20 z-30" />
-            <div className="w-full">
-              <LogoCloud variant="white" className="bg-transparent" />
+            <div className="w-full px-6 sm:px-16 lg:px-24">
+              <LogoCloud
+                variant="white"
+                className="bg-transparent px-0 sm:px-0 md:px-0"
+              />
             </div>
           </div>
         </div>

--- a/src/components/ui/Hero.tsx
+++ b/src/components/ui/Hero.tsx
@@ -53,7 +53,9 @@ export default async function Hero() {
             {/* Bottom Content - In front of everything */}
             <div className="relative z-20 mt-auto flex flex-col items-start w-full max-w-4xl opacity-0 animate-hero-content">
               <p className="text-lg sm:text-xl font-normal leading-[1.4] text-indigo-100 mt-6 mb-8">
-              One Postgres platform for your hardest search queries. Text and vector search, filters, facets, and joins where your OLTP database falls short.
+                One Postgres platform for your hardest search queries. Text and
+                vector search, filters, facets, and joins where your OLTP
+                database falls short.
               </p>
               <div className="flex flex-col sm:flex-row items-center gap-4 w-full max-w-sm sm:max-w-none sm:w-auto justify-start mb-6 sm:mb-8 sm:px-0">
                 <Button
@@ -86,7 +88,6 @@ export default async function Hero() {
                 <CopyableCommand code={installCommand} />
               </div>
             </div>
-
           </div>
         </div>
 

--- a/src/components/ui/HeroVisual.tsx
+++ b/src/components/ui/HeroVisual.tsx
@@ -43,7 +43,7 @@ export function HeroVisual() {
               width="100%"
               height="100%"
               colorBack="#4f46e500"
-              colorFront="#6366f1"
+              colorFront="#5e56ec"
               shape="wave"
               type="8x8"
               size={8}

--- a/src/components/ui/LogoCloud.tsx
+++ b/src/components/ui/LogoCloud.tsx
@@ -75,16 +75,19 @@ export default function LogoCloud({
   variant = "indigo",
   className,
 }: {
-  variant?: "indigo" | "white";
+  variant?: "indigo" | "white" | "light";
   className?: string;
 }) {
   const isIndigo = variant === "indigo";
   const isWhite = variant === "white";
+  const isLight = variant === "light";
 
   const logoClass = cx(
-    isIndigo || isWhite
-      ? "brightness-0 invert opacity-70"
-      : "brightness-0 dark:brightness-0 dark:invert opacity-80",
+    isLight
+      ? "brightness-0 dark:invert opacity-80"
+      : isIndigo || isWhite
+        ? "brightness-0 invert opacity-70"
+        : "brightness-0 dark:brightness-0 dark:invert opacity-80",
   );
 
   return (
@@ -93,9 +96,10 @@ export default function LogoCloud({
         "grid grid-cols-3 sm:flex sm:flex-wrap items-center sm:justify-between w-full py-10 md:py-12 px-6 sm:px-8 md:px-16 gap-y-10 sm:gap-y-8 gap-x-4",
         isIndigo
           ? "bg-[#4f46e5]"
-          : isWhite
+          : isWhite || isLight
             ? "bg-transparent"
             : "bg-white dark:bg-slate-950",
+        isLight && "[&_img]:scale-[0.9]",
         className,
       )}
     >

--- a/src/components/ui/Navbar.tsx
+++ b/src/components/ui/Navbar.tsx
@@ -294,7 +294,7 @@ export function Navigation() {
                     "aspect-square p-2 transition-colors border-0 hover:bg-transparent",
                     isHomePage && !open
                       ? "text-white hover:text-white/80"
-                      : "text-slate-900 dark:text-slate-100 hover:text-indigo-600 dark:hover:text-indigo-400",
+                      : "text-slate-900 dark:text-slate-100 hover:text-slate-600 dark:hover:text-slate-300",
                   )}
                 >
                   {open ? (

--- a/src/components/ui/PerformanceScroller.tsx
+++ b/src/components/ui/PerformanceScroller.tsx
@@ -112,7 +112,7 @@ const BENCHMARKS: {
   },
   {
     key: "aggregates",
-    label: "Aggregates",
+    label: "Facets",
     paradedbMs: 88.4,
     postgresMs: 3000,
     speedup: 34,
@@ -321,7 +321,7 @@ export default function PerformanceScroller({
                   aria-hidden="true"
                   className="hidden sm:block absolute -left-16 lg:-left-24 translate-x-[calc(-50%+0.5px)] top-[0.15em] h-[0.9em] w-[3px] bg-indigo-600 z-40"
                 />
-                  Ordinary SQL at extraordinary speeds.
+                Ordinary SQL at extraordinary speeds.
               </h2>
             </div>
 

--- a/src/components/ui/PerformanceScroller.tsx
+++ b/src/components/ui/PerformanceScroller.tsx
@@ -1,0 +1,443 @@
+"use client";
+
+import { type ReactNode, useEffect, useRef, useState } from "react";
+import {
+  RiBracesLine,
+  RiBubbleChartLine,
+  RiDatabase2Line,
+  RiFilter3Line,
+  RiFilterLine,
+  RiGitBranchLine,
+  RiGitMergeLine,
+  RiMapPinLine,
+  RiCpuLine,
+  RiLayoutVerticalLine,
+  RiPieChartLine,
+  RiRefreshLine,
+  RiSearchEyeLine,
+  RiStackLine,
+  RiTranslate2,
+} from "@remixicon/react";
+import { cx } from "@/lib/utils";
+
+export const ENGINES = [
+  { key: "paradedb", label: "ParadeDB" },
+  { key: "postgres", label: "Vanilla Postgres" },
+] as const;
+
+export type EngineKey = (typeof ENGINES)[number]["key"];
+
+// Timings (P95) from https://www.paradedb.com/vs/postgresql — Hacker News
+// benchmark, 28.7M rows. Speedups quoted from the published page.
+const BENCHMARKS: {
+  key: string;
+  label: string;
+  paradedbMs: number | null;
+  postgresMs: number | null;
+  speedup: number | null;
+  bullets: { lead?: string; text: string; icon?: ReactNode; badge?: string }[];
+}[] = [
+  {
+    key: "text",
+    label: "Text",
+    paradedbMs: 3.6,
+    postgresMs: 1900,
+    speedup: 538,
+    bullets: [
+      {
+        lead: "Tunable BM25 scoring,",
+        text: "the same lexical ranking used by dedicated search engines.",
+        icon: <RiSearchEyeLine className="size-5" />,
+      },
+      {
+        lead: "Elastic-style search:",
+        text: "typo tolerance, highlighting, phrase, fuzzy, proximity, and regex queries.",
+        icon: <RiBracesLine className="size-5" />,
+      },
+      {
+        lead: "Advanced text analysis",
+        text: "with support for 20+ languages and 12+ tokenizers.",
+        icon: <RiTranslate2 className="size-5" />,
+      },
+    ],
+  },
+  {
+    key: "vector",
+    label: "Vector",
+    paradedbMs: null,
+    postgresMs: null,
+    speedup: null,
+    bullets: [
+      {
+        lead: "State-of-the-art vector index:",
+        text: "hierarchical clustering built for larger-than-memory datasets.",
+        icon: <RiBubbleChartLine className="size-5" />,
+      },
+      {
+        lead: "Incremental maintenance (SPFresh)",
+        text: "keeps recall high as your data changes.",
+        icon: <RiRefreshLine className="size-5" />,
+        badge: "Coming soon",
+      },
+      {
+        lead: "Native filtering support:",
+        text: "combine vector similarity with SQL predicates in one index scan.",
+        icon: <RiFilterLine className="size-5" />,
+      },
+    ],
+  },
+  {
+    key: "filters",
+    label: "Filters",
+    paradedbMs: 22.4,
+    postgresMs: 846,
+    speedup: 38,
+    bullets: [
+      {
+        lead: "Filter any query,",
+        text: "text, vector, aggregate, or join. Filtering is native to the index, so performance doesn't degrade.",
+        icon: <RiFilter3Line className="size-5" />,
+      },
+      {
+        lead: "Filters compose:",
+        text: "booleans, ranges, and nested predicates stack without a performance cliff.",
+        icon: <RiStackLine className="size-5" />,
+      },
+      {
+        lead: "Specialized filters",
+        text: "like ltree and PostGIS intersect efficiently in the same query plan.",
+        icon: <RiMapPinLine className="size-5" />,
+      },
+    ],
+  },
+  {
+    key: "aggregates",
+    label: "Aggregates",
+    paradedbMs: 88.4,
+    postgresMs: 3000,
+    speedup: 34,
+    bullets: [
+      {
+        lead: "Columnar storage:",
+        text: "the index keeps fields in a column-oriented format, the same way analytical databases read data efficiently.",
+        icon: <RiLayoutVerticalLine className="size-5" />,
+      },
+      {
+        lead: "Parallel execution:",
+        text: "aggregates fan out across Postgres workers to keep large scans fast.",
+        icon: <RiCpuLine className="size-5" />,
+      },
+      {
+        lead: "Facets with results:",
+        text: "return facet counts alongside search hits in a single query.",
+        icon: <RiPieChartLine className="size-5" />,
+      },
+    ],
+  },
+  {
+    key: "joins",
+    label: "Joins",
+    paradedbMs: null,
+    postgresMs: null,
+    speedup: null,
+    bullets: [
+      {
+        lead: "Efficient pushdown:",
+        text: "search queries over joined tables are pushed down into the ParadeDB indexes instead of Postgres' row-based executor.",
+        icon: <RiGitMergeLine className="size-5" />,
+      },
+      {
+        lead: "Late materialization:",
+        text: "rows are fetched only for the final results, after the index has answered the join and sort.",
+        icon: <RiDatabase2Line className="size-5" />,
+      },
+      {
+        lead: "All join shapes:",
+        text: "INNER, LEFT, RIGHT, FULL, SEMI, and ANTI joins all can be accelerated.",
+        icon: <RiGitBranchLine className="size-5" />,
+      },
+    ],
+  },
+];
+
+function formatMs(ms: number) {
+  return ms >= 1000 ? `${(ms / 1000).toFixed(1)}s` : `${ms}ms`;
+}
+
+export type QueryPanels = Record<string, Record<EngineKey, ReactNode> | null>;
+
+function BarChart({
+  paradedbMs,
+  postgresMs,
+  speedup,
+}: {
+  paradedbMs: number;
+  postgresMs: number;
+  speedup: number;
+}) {
+  const rows = [
+    {
+      name: "ParadeDB",
+      ms: paradedbMs,
+      barClass: "bg-indigo-600",
+      badge: `${speedup}x faster`,
+    },
+    {
+      name: "Vanilla Postgres",
+      ms: postgresMs,
+      barClass: "bg-slate-300 dark:bg-slate-700",
+    },
+  ];
+  const max = Math.max(...rows.map((r) => r.ms));
+
+  return (
+    <div className="flex flex-col gap-5">
+      <p className="font-mono text-xs uppercase tracking-widest text-slate-400">
+        P95 latency &middot; lower is better
+      </p>
+      {rows.map((row) => (
+        <div key={row.name}>
+          <div className="flex items-baseline justify-between mb-1.5">
+            <span className="text-sm font-medium text-slate-900 dark:text-white">
+              {row.name}
+            </span>
+            <span className="font-mono text-sm text-slate-500 dark:text-slate-400">
+              {row.badge && (
+                <>
+                  <span className="font-sans font-semibold text-indigo-600 dark:text-indigo-400">
+                    {row.badge}
+                  </span>
+                  <span
+                    aria-hidden="true"
+                    className="mx-3 inline-block h-3 w-px translate-y-0.5 bg-slate-300 dark:bg-slate-700"
+                  />
+                </>
+              )}
+              {formatMs(row.ms)}
+            </span>
+          </div>
+          <div className="h-3 w-full bg-slate-100 dark:bg-slate-900">
+            <div
+              className={cx("h-full transition-all duration-500", row.barClass)}
+              style={{ width: `${Math.max((row.ms / max) * 100, 1.5)}%` }}
+            />
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+function PlaceholderChart() {
+  return (
+    <div aria-hidden="true" className="flex flex-col gap-5">
+      <p className="font-mono text-xs uppercase tracking-widest text-slate-400">
+        Benchmarks coming soon
+      </p>
+      {[0, 1].map((row) => (
+        <div key={row}>
+          <div className="flex items-baseline justify-between mb-1.5">
+            <span className="h-[21px] w-28 bg-slate-100 dark:bg-slate-900" />
+            <span className="h-[21px] w-14 bg-slate-100 dark:bg-slate-900" />
+          </div>
+          <div className="h-3 w-full bg-slate-100 dark:bg-slate-900" />
+        </div>
+      ))}
+    </div>
+  );
+}
+
+export default function PerformanceScroller({
+  queryPanels,
+}: {
+  queryPanels: QueryPanels;
+}) {
+  const trackRef = useRef<HTMLDivElement>(null);
+  const navRef = useRef<HTMLElement>(null);
+  const [active, setActive] = useState(0);
+  const [engine, setEngine] = useState<EngineKey>("paradedb");
+
+  useEffect(() => {
+    const nav = navRef.current;
+    const button = nav?.children[active] as HTMLElement | undefined;
+    if (!nav || !button || nav.scrollWidth <= nav.clientWidth) return;
+    nav.scrollTo({
+      left: button.offsetLeft - (nav.clientWidth - button.clientWidth) / 2,
+      behavior: "smooth",
+    });
+  }, [active]);
+
+  useEffect(() => {
+    const onScroll = () => {
+      const track = trackRef.current;
+      if (!track) return;
+      const total = track.offsetHeight - window.innerHeight;
+      const progress = Math.min(
+        Math.max(-track.getBoundingClientRect().top / total, 0),
+        0.999,
+      );
+      setActive(Math.floor(progress * BENCHMARKS.length));
+    };
+    onScroll();
+    window.addEventListener("scroll", onScroll, { passive: true });
+    return () => window.removeEventListener("scroll", onScroll);
+  }, []);
+
+  const scrollToTab = (index: number) => {
+    const track = trackRef.current;
+    if (!track) return;
+    const total = track.offsetHeight - window.innerHeight;
+    const top = window.scrollY + track.getBoundingClientRect().top;
+    window.scrollTo({
+      top: top + (total * (index + 0.5)) / BENCHMARKS.length,
+      behavior: "smooth",
+    });
+  };
+
+  const tab = BENCHMARKS[active];
+
+  return (
+    <section
+      aria-labelledby="performance-title"
+      className="w-full bg-white dark:bg-slate-950"
+    >
+      <div className="relative max-w-[1440px] mx-auto px-4 md:px-12">
+        <div className="absolute top-0 bottom-0 left-4 md:left-12 w-px bg-slate-200 dark:bg-slate-900 z-30 pointer-events-none" />
+        <div className="absolute top-0 bottom-0 right-4 md:right-12 w-px bg-slate-200 dark:bg-slate-900 z-30 pointer-events-none" />
+        <div className="border-y border-slate-200 dark:border-slate-900">
+          <div className="h-8 md:h-12 w-full bg-diagonal-hatch opacity-60" />
+        </div>
+        <div ref={trackRef} className="relative h-[500vh]">
+          <div className="sticky top-0 z-40 flex h-[88vh] flex-col justify-center px-6 sm:px-16 lg:px-24">
+            <div className="mb-6 sm:mb-10 md:mb-14 relative z-40">
+              <p className="font-mono text-xs uppercase tracking-widest text-indigo-600 dark:text-indigo-400 mb-3">
+                Performance
+              </p>
+              <h2
+                id="performance-title"
+                className="relative text-2xl sm:text-4xl font-semibold tracking-tight leading-[1.15] text-slate-900 dark:text-white"
+              >
+                <span
+                  aria-hidden="true"
+                  className="hidden sm:block absolute -left-16 lg:-left-24 translate-x-[calc(-50%+0.5px)] top-[0.15em] h-[0.9em] w-[3px] bg-indigo-600 z-40"
+                />
+                  Ordinary SQL at extraordinary speeds.
+              </h2>
+            </div>
+
+            <div className="grid grid-cols-1 lg:grid-cols-[1fr_200px] gap-10 lg:gap-20">
+              <div
+                key={tab.key}
+                className="animate-[slide-up-fade_600ms_cubic-bezier(0.16,1,0.3,1)]"
+              >
+                <div className="sm:min-h-[220px] border border-slate-200 dark:border-slate-800 bg-slate-50 dark:bg-slate-900/50 p-3 sm:p-5 mb-6 sm:mb-8">
+                  <div className="flex items-center justify-between mb-4">
+                    <p className="font-mono text-xs uppercase tracking-widest text-slate-400">
+                      {tab.label}
+                    </p>
+                    {queryPanels[tab.key] && (
+                      <div className="flex border border-slate-200 dark:border-slate-800">
+                        {ENGINES.map((option) => (
+                          <button
+                            key={option.key}
+                            onClick={() => setEngine(option.key)}
+                            className={cx(
+                              "cursor-pointer px-3 py-1 text-xs font-medium transition-colors",
+                              engine === option.key
+                                ? "bg-white dark:bg-slate-800 text-slate-900 dark:text-white"
+                                : "text-slate-400 hover:text-slate-600 dark:hover:text-slate-300",
+                            )}
+                          >
+                            {option.label}
+                          </button>
+                        ))}
+                      </div>
+                    )}
+                  </div>
+                  {queryPanels[tab.key]?.[engine] ?? (
+                    <p className="font-mono text-sm text-slate-400">
+                      Benchmarks coming soon.
+                    </p>
+                  )}
+                </div>
+
+                {tab.paradedbMs !== null &&
+                tab.postgresMs !== null &&
+                tab.speedup !== null ? (
+                  <BarChart
+                    paradedbMs={tab.paradedbMs}
+                    postgresMs={tab.postgresMs}
+                    speedup={tab.speedup}
+                  />
+                ) : (
+                  <PlaceholderChart />
+                )}
+
+                <ul className="mt-8 sm:mt-10 flex overflow-x-auto no-scrollbar sm:grid min-h-[104px] gap-5 sm:gap-6 sm:grid-cols-3">
+                  {tab.bullets.map((bullet) => (
+                    <li
+                      key={bullet.text}
+                      className="w-[78%] shrink-0 sm:w-auto sm:shrink"
+                    >
+                      <span className="mb-3 flex items-center gap-2">
+                        {bullet.icon ? (
+                          <span
+                            aria-hidden="true"
+                            className="text-indigo-600 dark:text-indigo-400"
+                          >
+                            {bullet.icon}
+                          </span>
+                        ) : (
+                          <span
+                            aria-hidden="true"
+                            className="block h-[3px] w-6 bg-indigo-600"
+                          />
+                        )}
+                        {bullet.badge && (
+                          <span className="border border-slate-200 dark:border-slate-700 px-1.5 py-0.5 font-mono text-[10px] uppercase tracking-widest text-slate-400">
+                            {bullet.badge}
+                          </span>
+                        )}
+                      </span>
+                      <span className="text-sm text-slate-600 dark:text-slate-300">
+                        {bullet.lead && (
+                          <>
+                            <span className="font-semibold text-slate-900 dark:text-white">
+                              {bullet.lead}
+                            </span>{" "}
+                          </>
+                        )}
+                        {bullet.text}
+                      </span>
+                    </li>
+                  ))}
+                </ul>
+              </div>
+
+              <nav
+                ref={navRef}
+                aria-label="Benchmark categories"
+                className="order-first lg:order-none flex lg:flex-col gap-1 overflow-x-auto no-scrollbar"
+              >
+                {BENCHMARKS.map((benchmark, index) => (
+                  <button
+                    key={benchmark.key}
+                    onClick={() => scrollToTab(index)}
+                    className={cx(
+                      "cursor-pointer whitespace-nowrap border-b-2 lg:border-b-0 lg:border-l-2 px-3 py-2 text-left text-sm font-medium transition-colors",
+                      index === active
+                        ? "border-indigo-600 text-slate-900 dark:text-white"
+                        : "border-slate-200 dark:border-slate-800 text-slate-400 hover:text-slate-600 dark:hover:text-slate-300",
+                    )}
+                  >
+                    {benchmark.label}
+                  </button>
+                ))}
+              </nav>
+            </div>
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/src/components/ui/PerformanceSection.tsx
+++ b/src/components/ui/PerformanceSection.tsx
@@ -1,0 +1,96 @@
+import Code from "@/components/Code";
+import { paradedbSqlLight, paradedbSqlDark } from "./paradedbSqlTheme";
+import PerformanceScroller, { type QueryPanels } from "./PerformanceScroller";
+
+// Queries and timings from https://www.paradedb.com/vs/postgresql
+// (Hacker News benchmark, 28.7M rows).
+const QUERIES: Record<string, { paradedb: string; postgres: string } | null> = {
+  text: {
+    paradedb: `SELECT id, title, by, score
+FROM hn_items
+WHERE text ||| 'rust'
+ORDER BY pdb.score(id) DESC
+LIMIT 10`,
+    postgres: `SELECT id, title, by, score
+FROM hn_items
+WHERE text_tsv @@
+      websearch_to_tsquery('english', 'rust')
+ORDER BY ts_rank_cd(text_tsv,
+      websearch_to_tsquery('english', 'rust')) DESC
+LIMIT 10`,
+  },
+  vector: null,
+  filters: {
+    paradedb: `SELECT id, title, by, score
+FROM hn_items
+WHERE text ||| 'rust'
+  AND type = 'story'
+ORDER BY pdb.score(id) DESC
+LIMIT 10`,
+    postgres: `SELECT id, title, by, score
+FROM hn_items
+WHERE text_tsv @@
+      websearch_to_tsquery('english', 'rust')
+  AND type = 'story'
+ORDER BY ts_rank_cd(text_tsv,
+      websearch_to_tsquery('english', 'rust')) DESC
+LIMIT 10`,
+  },
+  aggregates: {
+    paradedb: `SELECT id,
+  pdb.agg('{"terms": {"field": "type"}}') OVER ()
+FROM hn_items
+WHERE text ||| 'rust'
+ORDER BY pdb.score(id) DESC
+LIMIT 10`,
+    postgres: `WITH hits AS (
+  SELECT id, type,
+    ts_rank_cd(text_tsv, q) r
+  FROM hn_items,
+    websearch_to_tsquery('english', 'rust') q
+  WHERE text_tsv @@ q
+)
+SELECT
+  (SELECT jsonb_object_agg(k, c)
+   FROM (SELECT type k, count(*) c FROM hits
+         GROUP BY 1) t),
+  (SELECT jsonb_agg(h)
+   FROM (SELECT * FROM hits
+         ORDER BY r DESC LIMIT 10) h)`,
+  },
+  joins: null,
+};
+
+export default function PerformanceSection() {
+  const queryPanels: QueryPanels = Object.fromEntries(
+    Object.entries(QUERIES).map(([key, queries]) => [
+      key,
+      queries === null
+        ? null
+        : {
+        paradedb: (
+          <Code
+            code={queries.paradedb}
+            lang="sql"
+            themeLight={paradedbSqlLight}
+            themeDark={paradedbSqlDark}
+            className="[&_pre]:!bg-transparent [&>div]:text-xs sm:[&>div]:text-sm [&_pre]:!p-0 [&_pre]:overflow-x-auto"
+            copy={false}
+          />
+        ),
+        postgres: (
+          <Code
+            code={queries.postgres}
+            lang="sql"
+            themeLight={paradedbSqlLight}
+            themeDark={paradedbSqlDark}
+            className="[&_pre]:!bg-transparent [&>div]:text-xs sm:[&>div]:text-sm [&_pre]:!p-0 [&_pre]:overflow-x-auto"
+            copy={false}
+          />
+        ),
+      },
+    ]),
+  );
+
+  return <PerformanceScroller queryPanels={queryPanels} />;
+}

--- a/src/components/ui/PerformanceSection.tsx
+++ b/src/components/ui/PerformanceSection.tsx
@@ -68,27 +68,27 @@ export default function PerformanceSection() {
       queries === null
         ? null
         : {
-        paradedb: (
-          <Code
-            code={queries.paradedb}
-            lang="sql"
-            themeLight={paradedbSqlLight}
-            themeDark={paradedbSqlDark}
-            className="[&_pre]:!bg-transparent [&>div]:text-xs sm:[&>div]:text-sm [&_pre]:!p-0 [&_pre]:overflow-x-auto"
-            copy={false}
-          />
-        ),
-        postgres: (
-          <Code
-            code={queries.postgres}
-            lang="sql"
-            themeLight={paradedbSqlLight}
-            themeDark={paradedbSqlDark}
-            className="[&_pre]:!bg-transparent [&>div]:text-xs sm:[&>div]:text-sm [&_pre]:!p-0 [&_pre]:overflow-x-auto"
-            copy={false}
-          />
-        ),
-      },
+            paradedb: (
+              <Code
+                code={queries.paradedb}
+                lang="sql"
+                themeLight={paradedbSqlLight}
+                themeDark={paradedbSqlDark}
+                className="[&_pre]:!bg-transparent [&>div]:text-xs sm:[&>div]:text-sm [&_pre]:!p-0 [&_pre]:overflow-x-auto"
+                copy={false}
+              />
+            ),
+            postgres: (
+              <Code
+                code={queries.postgres}
+                lang="sql"
+                themeLight={paradedbSqlLight}
+                themeDark={paradedbSqlDark}
+                className="[&_pre]:!bg-transparent [&>div]:text-xs sm:[&>div]:text-sm [&_pre]:!p-0 [&_pre]:overflow-x-auto"
+                copy={false}
+              />
+            ),
+          },
     ]),
   );
 

--- a/src/components/ui/PostgresNative.tsx
+++ b/src/components/ui/PostgresNative.tsx
@@ -23,7 +23,8 @@ const KEEPS = [
     title: "Shipped as an extension",
     body: (
       <>
-        Pure Postgres extension, not a fork. Drops into any self-managed Postgres. Or{" "}
+        Pure Postgres extension, not a fork. Drops into any self-managed
+        Postgres. Or{" "}
         <Link
           href={social.CALENDLY}
           target="_blank"
@@ -65,7 +66,8 @@ const KEEPS = [
     title: "Replicates like Postgres",
     body: (
       <>
-        High availability from physical replicas, horizontal scaling from read replicas. An{" "}
+        High availability from physical replicas, horizontal scaling from read
+        replicas. An{" "}
         <Link
           href="#pricing"
           className="text-indigo-600 dark:text-indigo-400 underline underline-offset-2 hover:text-indigo-700 dark:hover:text-indigo-300"
@@ -191,11 +193,7 @@ export default function PostgresNative() {
             <SectionHeader
               cursor="gutter"
               eyebrow="Architecture"
-              title={
-                <>
-                  No bespoke search engine. Just use Postgres.
-                </>
-              }
+              title={<>No bespoke search engine. Just use Postgres.</>}
               description={
                 <>
                   The world's{" "}

--- a/src/components/ui/PostgresNative.tsx
+++ b/src/components/ui/PostgresNative.tsx
@@ -3,26 +3,27 @@
 import { useEffect, useRef, useState } from "react";
 import { useTheme } from "next-themes";
 import { cx } from "@/lib/utils";
-import { Badge } from "./Badge";
+import { SectionHeader } from "./SectionHeader";
 import PixelShadow from "./PixelShadow";
-import { Button } from "../Button";
 import Link from "next/link";
-import { documentation, social } from "@/lib/links";
+import { social } from "@/lib/links";
 import {
   RiTerminalBoxLine,
   RiShieldKeyholeLine,
+  RiHardDrive2Line,
   RiLifebuoyLine,
+  RiListCheck2,
   RiPlugLine,
   RiPuzzleLine,
+  RiServerLine,
 } from "@remixicon/react";
 
 const KEEPS = [
   {
-    title: "Built as an extension",
+    title: "Shipped as an extension",
     body: (
       <>
-        Pure Postgres extension. Drops into any self-managed Postgres with no
-        fork and no separate server. Or{" "}
+        Pure Postgres extension, not a fork. Drops into any self-managed Postgres. Or{" "}
         <Link
           href={social.CALENDLY}
           target="_blank"
@@ -37,6 +38,12 @@ const KEEPS = [
     code: "CREATE EXTENSION pg_search;",
   },
   {
+    title: "Built as an index",
+    body: "No sidecar process, no external cluster — just a native index on your tables.",
+    icon: <RiListCheck2 className="size-[18px]" />,
+    code: "CREATE INDEX … USING paradedb;",
+  },
+  {
     title: "Standard SQL",
     body: "Joins, CTEs, window functions, JSONB, PL/pgSQL, row level security (RLS), materialized views. Search is a WHERE clause.",
     icon: <RiTerminalBoxLine className="size-[18px]" />,
@@ -49,6 +56,29 @@ const KEEPS = [
     code: "BEGIN; … COMMIT;",
   },
   {
+    title: "Durable by default",
+    body: "Writes go through the Postgres write-ahead log, so the index gets the same crash recovery guarantees as your tables.",
+    icon: <RiHardDrive2Line className="size-[18px]" />,
+    code: "CHECKPOINT;",
+  },
+  {
+    title: "Replicates like Postgres",
+    body: (
+      <>
+        High availability from physical replicas, horizontal scaling from read replicas. An{" "}
+        <Link
+          href="#pricing"
+          className="text-indigo-600 dark:text-indigo-400 underline underline-offset-2 hover:text-indigo-700 dark:hover:text-indigo-300"
+        >
+          enterprise feature
+        </Link>
+        .
+      </>
+    ),
+    icon: <RiServerLine className="size-[18px]" />,
+    code: "pg_basebackup -R …",
+  },
+  {
     title: "Your usual ops surface",
     body: "pg_dump, logical replication, high availability, pgBackRest, the dashboards and alerting your team already trusts.",
     icon: <RiLifebuoyLine className="size-[18px]" />,
@@ -56,9 +86,9 @@ const KEEPS = [
   },
   {
     title: "The Postgres ecosystem",
-    body: "pgvector, pg_partman, pg_cron, PostGIS, and the rest of the extension catalog work side by side.",
+    body: "pg_partman, pg_cron, PostGIS, and the rest of the extension catalog work side by side.",
     icon: <RiPuzzleLine className="size-[18px]" />,
-    code: "CREATE EXTENSION vector;",
+    code: "CREATE EXTENSION pg_cron;",
   },
 ];
 
@@ -143,41 +173,43 @@ export default function PostgresNative() {
   return (
     <div
       ref={sectionRef}
-      className="w-full relative bg-white dark:bg-slate-950 border-t border-slate-200 dark:border-slate-900"
+      className="w-full relative bg-white dark:bg-slate-950"
     >
       <div className="max-w-[1440px] mx-auto px-4 md:px-12 relative w-full">
         {/* Vertical guide lines */}
         <div className="absolute inset-y-0 left-4 md:left-12 w-px bg-slate-200 dark:bg-slate-900 z-30 pointer-events-none" />
         <div className="absolute inset-y-0 right-4 md:right-12 w-px bg-slate-200 dark:bg-slate-900 z-30 pointer-events-none" />
 
-        <section className="relative py-10 md:py-16 border-r border-l border-slate-200 dark:border-slate-900 bg-white dark:bg-slate-950">
+        {/* Shaded hatch divider */}
+        <div className="border-y border-slate-200 dark:border-slate-900">
+          <div className="h-8 md:h-12 w-full bg-diagonal-hatch opacity-60" />
+        </div>
+
+        <section className="relative z-40 py-10 md:py-16 border-r border-l border-slate-200 dark:border-slate-900 bg-white dark:bg-slate-950">
           {/* Header */}
-          <div className="flex flex-col items-center text-center px-6 sm:px-12 mb-10 md:mb-12">
-            <Badge className="mb-6">OLTP</Badge>
-            <h2 className="text-3xl sm:text-4xl font-bold tracking-tighter text-indigo-950 dark:text-white sm:text-6xl mb-6 max-w-4xl">
-              Built on <span className="text-highlight-blink">Postgres</span>.
-            </h2>
-            <p className="text-base sm:text-lg text-gray-800 dark:text-slate-300 max-w-4xl leading-relaxed">
-              The world's{" "}
-              <Link
-                href="https://survey.stackoverflow.co/2025/technology#2-databases"
-                target="_blank"
-                className="text-indigo-600 dark:text-indigo-400 hover:text-indigo-700 dark:hover:text-indigo-300"
-              >
-                most-admired
-              </Link>{" "}
-              open-source database, proven in production at every scale.
-            </p>
-            <div className="mt-8 flex flex-col sm:flex-row gap-3 sm:items-center">
-              <Button
-                asChild
-                className="text-md px-6 py-2 bg-indigo-600 ring-2 ring-indigo-400 dark:ring-indigo-600/50 border-1 border-indigo-400 dark:border-indigo-600 rounded-none hover:bg-indigo-700 transition-all"
-              >
-                <Link href={documentation.GETTING_STARTED} target="_blank">
-                  Install ParadeDB
-                </Link>
-              </Button>
-            </div>
+          <div className="flex flex-col items-start text-left px-6 sm:px-16 lg:px-24 mb-10 md:mb-12">
+            <SectionHeader
+              cursor="gutter"
+              eyebrow="Architecture"
+              title={
+                <>
+                  No bespoke search engine. Just use Postgres.
+                </>
+              }
+              description={
+                <>
+                  The world's{" "}
+                  <Link
+                    href="https://survey.stackoverflow.co/2025/technology#2-databases"
+                    target="_blank"
+                    className="text-indigo-600 dark:text-indigo-400 hover:text-indigo-700 dark:hover:text-indigo-300"
+                  >
+                    most-admired
+                  </Link>{" "}
+                  open-source database, proven in production at every scale.
+                </>
+              }
+            />
           </div>
 
           {/* Keeps bento */}
@@ -188,7 +220,7 @@ export default function PostgresNative() {
               </span>
               <span className="flex-1 h-px bg-slate-200 dark:bg-slate-800" />
               <span className="text-[10px] font-mono uppercase tracking-[0.18em] text-slate-400 dark:text-slate-600">
-                05 / 05
+                08 / 08
               </span>
             </div>
 

--- a/src/components/ui/PreFooterCta.tsx
+++ b/src/components/ui/PreFooterCta.tsx
@@ -23,7 +23,7 @@ export default function PreFooterCta() {
   return (
     <div className="w-full relative">
       {/* White Grid Divider Section - Full Width Background */}
-      <div className="hidden sm:block w-full bg-white dark:bg-slate-950 relative border-t border-slate-200 dark:border-slate-900">
+      <div className="hidden sm:block w-full bg-white dark:bg-slate-950 relative">
         <div className="max-w-[1440px] mx-auto relative px-4 md:px-12">
           <div className="absolute inset-y-0 left-4 md:left-12 w-px bg-slate-200 dark:bg-slate-900 z-30 pointer-events-none" />
           <div className="absolute inset-y-0 right-4 md:right-12 w-px bg-slate-200 dark:bg-slate-900 z-30 pointer-events-none" />
@@ -43,12 +43,9 @@ export default function PreFooterCta() {
 
           <div className="relative flex flex-col items-center justify-center pt-16 md:pt-20 pb-4 md:pb-6 text-center">
             <div className="relative z-20 flex flex-col items-center px-6 sm:px-0">
-              <h2 className="text-3xl sm:text-4xl font-bold tracking-tighter text-white sm:text-6xl leading-[1.1] text-center">
-                Search where <br className="hidden sm:block" />
-                your data{" "}
-                <span className="text-highlight-blink !text-white after:!bg-white/10 after:!bg-gradient-to-r after:!from-white/20 after:!to-transparent">
-                  lives.
-                </span>
+              <h2 className="text-3xl sm:text-6xl font-bold tracking-tight leading-[1.15] text-white">
+                Search where <br />
+                your data lives.
               </h2>
               <div className="flex flex-col sm:flex-row gap-4 w-full sm:w-auto mt-8">
                 <Button

--- a/src/components/ui/Pricing.tsx
+++ b/src/components/ui/Pricing.tsx
@@ -1,4 +1,5 @@
 import { Badge } from "./Badge";
+import { SectionHeader } from "./SectionHeader";
 import { Button } from "../Button";
 import Link from "next/link";
 import { RiCheckLine } from "@remixicon/react";
@@ -76,29 +77,22 @@ export default function Pricing() {
         <div className="absolute inset-y-0 left-4 md:left-12 w-px bg-slate-200 dark:bg-slate-900 z-30 pointer-events-none" />
         <div className="absolute inset-y-0 right-4 md:right-12 w-px bg-slate-200 dark:bg-slate-900 z-30 pointer-events-none" />
 
-        <div className="px-4 md:px-12 w-full flex flex-col relative isolate">
-          {/* Background color layer */}
-          <div className="absolute inset-y-0 left-4 md:left-12 right-4 md:right-12 bg-slate-100/60 dark:bg-slate-900/40 z-0" />
-
-          {/* Inner Vertical Borders for boxed look */}
-          <div className="absolute inset-y-0 left-1/2 -ml-[564px] w-px bg-slate-200 dark:bg-slate-900 z-30 pointer-events-none hidden xl:block" />
-          <div className="absolute inset-y-0 left-1/2 ml-[564px] w-px bg-slate-200 dark:bg-slate-900 z-30 pointer-events-none hidden xl:block" />
-
-          <div className="relative z-10 flex flex-col items-center justify-center py-10 sm:py-16 text-center bg-transparent">
+        <div className="px-4 md:px-12 w-full flex flex-col relative">
+          <div className="relative flex flex-col items-center justify-center py-10 sm:py-16 text-center bg-transparent">
             {/* Header section */}
-            <div className="flex flex-col items-center w-full relative z-20 px-6 sm:px-0">
-              <Badge className="mb-6">Pricing</Badge>
-              <h2 className="text-3xl sm:text-4xl font-bold tracking-tighter text-indigo-950 dark:text-white sm:text-6xl mb-4">
-                Ready, set, <span className="text-highlight-blink">deploy</span>
-                .
-              </h2>
-              <p className="text-base sm:text-lg text-gray-800 dark:text-slate-300 max-w-2xl mx-auto leading-relaxed mb-12">
-                Scale search on Postgres with confidence.
-              </p>
+            <div className="mx-auto w-full max-w-[1128px] px-4 sm:px-12 xl:px-0 relative">
+              <SectionHeader
+                eyebrow="Pricing"
+                title="Ready, set, deploy."
+                description="Scale search on Postgres with confidence."
+                className="mb-12"
+              />
             </div>
 
             {/* Nested Cards Container */}
             <div className="relative w-full z-20">
+              <div className="absolute inset-y-0 left-1/2 -ml-[564px] w-px bg-slate-200 dark:bg-slate-900 z-30 pointer-events-none hidden xl:block" />
+              <div className="absolute inset-y-0 left-1/2 ml-[564px] w-px bg-slate-200 dark:bg-slate-900 z-30 pointer-events-none hidden xl:block" />
               <div className="max-w-[1128px] mx-auto grid grid-cols-1 md:grid-cols-3 border-y border-slate-200 dark:border-slate-800 divide-y md:divide-y-0 md:divide-x divide-slate-200 dark:divide-slate-800">
                 <PricingCard
                   planName="Community"

--- a/src/components/ui/SectionHeader.tsx
+++ b/src/components/ui/SectionHeader.tsx
@@ -21,7 +21,10 @@ export function SectionHeader({
 }) {
   return (
     <div
-      className={cx("flex flex-col items-start text-left relative z-40", className)}
+      className={cx(
+        "flex flex-col items-start text-left relative z-40",
+        className,
+      )}
     >
       <p className="font-mono text-xs uppercase tracking-widest text-indigo-600 dark:text-indigo-400 mb-3">
         {eyebrow}

--- a/src/components/ui/SectionHeader.tsx
+++ b/src/components/ui/SectionHeader.tsx
@@ -1,0 +1,48 @@
+import { type ReactNode } from "react";
+import { cx } from "@/lib/utils";
+
+export function SectionHeader({
+  eyebrow,
+  title,
+  description,
+  className,
+  cursor = "column",
+}: {
+  eyebrow: string;
+  title: ReactNode;
+  description?: ReactNode;
+  className?: string;
+  /**
+   * Horizontal anchor for the cursor tick so it lands on the left rule:
+   * "column" for headers aligned to the 1128px content column,
+   * "gutter" for headers using the splash px-16/px-24 gutter.
+   */
+  cursor?: "column" | "gutter";
+}) {
+  return (
+    <div
+      className={cx("flex flex-col items-start text-left relative z-40", className)}
+    >
+      <p className="font-mono text-xs uppercase tracking-widest text-indigo-600 dark:text-indigo-400 mb-3">
+        {eyebrow}
+      </p>
+      <h2 className="relative text-2xl sm:text-4xl font-semibold tracking-tight leading-[1.15] text-slate-900 dark:text-white">
+        <span
+          aria-hidden="true"
+          className={cx(
+            "hidden sm:block absolute translate-x-[calc(-50%+0.5px)] top-[0.15em] h-[0.9em] w-[3px] bg-indigo-600 z-40",
+            cursor === "gutter"
+              ? "left-[-65px] lg:left-[-97px]"
+              : "-left-12 xl:left-[calc(612px_-_min(100vw,1440px)/2)]",
+          )}
+        />
+        {title}
+      </h2>
+      {description && (
+        <p className="text-lg sm:text-xl font-normal leading-[1.4] text-slate-600 dark:text-slate-300 mt-4 max-w-3xl">
+          {description}
+        </p>
+      )}
+    </div>
+  );
+}

--- a/src/components/ui/SiteBanner.tsx
+++ b/src/components/ui/SiteBanner.tsx
@@ -11,7 +11,7 @@ export function SiteBanner() {
   // The banner links to the cloud waitlist, so skip it on the waitlist pages.
   if (pathname === "/cloud" || pathname.startsWith("/cloud/")) return null;
   return (
-    <div className="relative z-50 w-full bg-indigo-600">
+    <div className="relative z-50 w-full bg-slate-950">
       <Link
         href="/cloud"
         className="group flex w-full items-center justify-center gap-2 border-b border-white/20 bg-white/10 px-4 py-3 text-center text-xs font-medium text-white opacity-0 animate-fade-in backdrop-blur-md transition-colors hover:bg-white/15 sm:text-sm"

--- a/src/components/ui/SocialProof.tsx
+++ b/src/components/ui/SocialProof.tsx
@@ -1,7 +1,7 @@
 import Link from "next/link";
 import Image from "next/image";
 import { RiArrowRightLine } from "@remixicon/react";
-import { Badge } from "./Badge";
+import { SectionHeader } from "./SectionHeader";
 
 const CaseStudyCard = ({
   logo,
@@ -52,73 +52,63 @@ export default function SocialProof() {
         <div className="absolute inset-y-0 left-4 md:left-12 w-px bg-slate-200 dark:bg-slate-900 z-30 pointer-events-none" />
         <div className="absolute inset-y-0 right-4 md:right-12 w-px bg-slate-200 dark:bg-slate-900 z-30 pointer-events-none" />
 
-        {/* Additional Vertical Lines */}
-        <div className="absolute inset-y-0 left-1/2 -ml-[564px] w-px bg-slate-200 dark:bg-slate-900 z-30 pointer-events-none hidden xl:block" />
-        <div className="absolute inset-y-0 left-1/2 ml-[564px] w-px bg-slate-200 dark:bg-slate-900 z-30 pointer-events-none hidden xl:block" />
-
-        <div className="px-4 md:px-12 w-full flex flex-col relative isolate">
-          {/* Background color layer */}
-          <div className="absolute inset-y-0 left-4 md:left-12 right-4 md:right-12 bg-slate-100/60 dark:bg-slate-900/40 z-0" />
-
-          {/* Inner Vertical Borders for boxed look */}
-          <div className="absolute inset-y-0 left-1/2 -ml-[564px] w-px bg-slate-200 dark:bg-slate-900 z-30 pointer-events-none hidden xl:block" />
-          <div className="absolute inset-y-0 left-1/2 ml-[564px] w-px bg-slate-200 dark:bg-slate-900 z-30 pointer-events-none hidden xl:block" />
-
+        <div className="px-4 md:px-12 w-full flex flex-col relative">
           {/* Section 1: Case Studies */}
-          <div className="relative z-10 flex flex-col items-center justify-center sm:py-16 py-10 text-center bg-transparent">
+          <div className="relative flex flex-col items-center justify-center sm:py-16 py-10 text-center bg-transparent">
             {/* Fades for Case Studies Section */}
             <div className="absolute bottom-0 left-0 right-0 h-32 bg-gradient-to-t from-white dark:from-slate-950 to-transparent z-0 pointer-events-none" />
 
-            <div className="flex flex-col items-center w-full relative z-20 px-6 sm:px-0">
-              <Badge className="mb-6 mt-px ml-px">Case Studies</Badge>
-              <h2 className="text-3xl sm:text-4xl font-bold tracking-tighter text-indigo-950 dark:text-white sm:text-6xl mb-4">
-                <span className="text-highlight-blink">Trusted</span> by
-                enterprises.
-              </h2>
-              <p className="text-base sm:text-lg text-gray-800 dark:text-slate-300 max-w-2xl mx-auto leading-relaxed mb-12 px-2">
-                The most innovative companies are simplifying their stack with
-                ParadeDB.
-              </p>
+            <div className="mx-auto w-full max-w-[1128px] px-4 sm:px-12 xl:px-0 relative">
+              <SectionHeader
+                eyebrow="Case Studies"
+                title="Trusted by enterprises."
+                description="The most innovative companies are simplifying their stack with ParadeDB."
+                className="mb-12"
+              />
             </div>
 
             <div className="relative w-full z-20">
-              <div className="max-w-[1128px] mx-auto grid grid-cols-1 md:grid-cols-2 bg-white dark:bg-slate-900/50 border-y border-slate-200 dark:border-slate-900">
-                <div className="border-b md:border-b-0 md:border-r border-slate-200 dark:border-slate-900">
-                  <CaseStudyCard
-                    href="/customers/case-study-bilt"
-                    logo={
-                      <Image
-                        src="/brand/customers/bilt-rewards.svg"
-                        alt="Bilt Rewards"
-                        width={179}
-                        height={30}
-                        className="h-4 w-auto opacity-80 dark:brightness-0 dark:invert"
-                      />
-                    }
-                    quote="“Using ParadeDB has unlocked the ability to rapidly launch new search capabilities across our products — something that previously would have taken weeks of effort.”"
-                    initials="JK"
-                    author="John King"
-                    role="Backend Engineer, Bilt"
-                  />
-                </div>
+              <div className="relative">
+                <div className="absolute inset-y-0 left-1/2 -ml-[564px] w-px bg-slate-200 dark:bg-slate-900 z-30 pointer-events-none hidden xl:block" />
+                <div className="absolute inset-y-0 left-1/2 ml-[564px] w-px bg-slate-200 dark:bg-slate-900 z-30 pointer-events-none hidden xl:block" />
+                <div className="max-w-[1128px] mx-auto grid grid-cols-1 md:grid-cols-2 bg-white dark:bg-slate-900/50 border-y border-slate-200 dark:border-slate-900">
+                  <div className="border-b md:border-b-0 md:border-r border-slate-200 dark:border-slate-900">
+                    <CaseStudyCard
+                      href="/customers/case-study-bilt"
+                      logo={
+                        <Image
+                          src="/brand/customers/bilt-rewards.svg"
+                          alt="Bilt Rewards"
+                          width={179}
+                          height={30}
+                          className="h-4 w-auto opacity-80 dark:brightness-0 dark:invert"
+                        />
+                      }
+                      quote="“Using ParadeDB has unlocked the ability to rapidly launch new search capabilities across our products — something that previously would have taken weeks of effort.”"
+                      initials="JK"
+                      author="John King"
+                      role="Backend Engineer, Bilt"
+                    />
+                  </div>
 
-                <div>
-                  <CaseStudyCard
-                    href="/customers/case-study-alibaba"
-                    logo={
-                      <Image
-                        src="/brand/customers/alibaba.svg"
-                        alt="Alibaba"
-                        width={127}
-                        height={30}
-                        className="h-8 w-auto opacity-80 dark:brightness-0 dark:invert"
-                      />
-                    }
-                    quote="“ParadeDB has excellent performance and throughput in search, helping our clients achieve structured analysis and full-text retrieval using a pure Postgres engine.”"
-                    initials="PB"
-                    author="Pang Bo"
-                    role="Product Manager, Alibaba"
-                  />
+                  <div>
+                    <CaseStudyCard
+                      href="/customers/case-study-alibaba"
+                      logo={
+                        <Image
+                          src="/brand/customers/alibaba.svg"
+                          alt="Alibaba"
+                          width={127}
+                          height={30}
+                          className="h-8 w-auto opacity-80 dark:brightness-0 dark:invert"
+                        />
+                      }
+                      quote="“ParadeDB has excellent performance and throughput in search, helping our clients achieve structured analysis and full-text retrieval using a pure Postgres engine.”"
+                      initials="PB"
+                      author="Pang Bo"
+                      role="Product Manager, Alibaba"
+                    />
+                  </div>
                 </div>
               </div>
 

--- a/src/components/ui/SocialProof.tsx
+++ b/src/components/ui/SocialProof.tsx
@@ -62,7 +62,7 @@ export default function SocialProof() {
               <SectionHeader
                 eyebrow="Case Studies"
                 title="Trusted by enterprises."
-                description="The most innovative companies are simplifying their stack with ParadeDB."
+                description="The most innovative companies build better search experiences on ParadeDB."
                 className="mb-12"
               />
             </div>

--- a/src/landings/default.tsx
+++ b/src/landings/default.tsx
@@ -1,8 +1,7 @@
 import Hero from "@/components/ui/Hero";
+import PerformanceSection from "@/components/ui/PerformanceSection";
 import Architecture from "@/components/ui/Architecture";
-import SearchFeatures from "@/components/ui/SearchFeatures";
 import PostgresNative from "@/components/ui/PostgresNative";
-import Benchmark from "@/components/ui/Benchmark";
 import SocialProof from "@/components/ui/SocialProof";
 import CommunityProof from "@/components/ui/CommunityProof";
 import Pricing from "@/components/ui/Pricing";
@@ -11,19 +10,16 @@ import PreFooterCta from "@/components/ui/PreFooterCta";
 
 export default function DefaultLanding() {
   return (
-    <main className="flex flex-col overflow-hidden px-0">
+    <main className="flex flex-col overflow-x-clip px-0">
       <Hero />
-      <div id="architecture">
-        <Architecture />
-      </div>
-      <div id="features">
-        <SearchFeatures />
+      <div id="performance">
+        <PerformanceSection />
       </div>
       <div id="postgres">
         <PostgresNative />
       </div>
-      <div id="benchmarks">
-        <Benchmark />
+      <div id="architecture">
+        <Architecture />
       </div>
       <div id="customers">
         <SocialProof />


### PR DESCRIPTION
## Summary

Homepage redesign around new messaging. Intended as an RFC — nothing here is final.

### Hero
- Left-aligned splash on indigo: waitlist pill, cursor accent on the rule line, inline click-to-copy install command, dithered wave above the logo cloud

### New Performance section
- Scroll-driven tabs (Text / Vector / Filters / Aggregates / Joins) with real p95 numbers and queries from [paradedb.com/vs/postgresql](https://www.paradedb.com/vs/postgresql), a ParadeDB vs. vanilla Postgres query toggle, and per-workload feature cards (Vector/Joins benchmarks marked coming soon)

### Section restyle
- Shared `SectionHeader`: mono eyebrow, left-aligned heading, indigo cursor tick sitting on the left rule — applied to every section
- Architecture: tabs removed; the two tab narratives are now cards under the diagram
- "Just use Postgres": new cards for index architecture, durability (WAL), and replication (enterprise-flagged)
- Benchmark + SearchFeatures sections removed from the landing; OLTP/Architecture order swapped; site banner replaced by the hero pill

### Fixes along the way
- `DarkModeOverlay` hydration mismatch, mobile layout for the perf scroller, `no-scrollbar` utility now actually defined

🤖 Generated with [Claude Code](https://claude.com/claude-code)